### PR TITLE
adding dedup functionality to multiple files found

### DIFF
--- a/plugins/module_utils/sap_launchpad_software_center_download_runner.py
+++ b/plugins/module_utils/sap_launchpad_software_center_download_runner.py
@@ -20,18 +20,25 @@ _HAS_DOWNLOAD_AUTHORIZATION = None
 MAX_RETRY_TIMES = 3
 
 
-def search_software_filename(name):
+def search_software_filename(name, dedup):
     """Return a single software that matched the filename
     """
     search_results = _search_software(name)
     softwares = [r for r in search_results if r['Title'] == name or r['Description'] == name]
-    if len(softwares) == 0:
+    num_files=len(softwares)
+    if num_files == 0:
         raise ValueError(f'no result found for {name}')
-    if len(softwares) > 1:
-        names = [s['Title'] for s in softwares]
-        raise ValueError('more than one results were found: %s. '
-                         'please use the correct full filename' % names)
-    software = softwares[0]
+    elif num_files > 1 and dedup == '':
+            names = [s['Title'] for s in softwares]
+            raise ValueError('more than one results were found: %s. '
+                             'please use the correct full filename' % names)
+    elif num_files > 1 and dedup == 'first':
+            software = softwares[0]
+    elif num_files > 1 and dedup == 'last':
+            software = softwares[num_files-1]
+    else:
+            software = softwares[0]
+    
     download_link, filename = software['DownloadDirectLink'], name
     return (download_link, filename)
 

--- a/plugins/modules/software_center_download.py
+++ b/plugins/modules/software_center_download.py
@@ -46,6 +46,11 @@ options:
       - Destination folder.
     required: true
     type: str
+  dedup:
+    description:
+      - How to handle multiple search results.
+    required: false
+    type: str
 author:
     - Lab for SAP Solutions
 
@@ -95,7 +100,8 @@ def run_module():
         download_link=dict(type='str', required=False, default=''),
         download_filename=dict(type='str', required=False, default=''),
         dest=dict(type='str', required=True),
-        dry_run=dict(type='bool', required=False, default=False)
+        dry_run=dict(type='bool', required=False, default=False),
+        dedup=dict(type='str', required=False, default='')
     )
 
     # Define result dictionary objects to be passed back to Ansible
@@ -122,6 +128,7 @@ def run_module():
     download_filename= module.params.get('download_filename')
     dest = module.params.get('dest')
     dry_run = module.params.get('dry_run')
+    dedup = module.params.get('dedup')
 
     # Main run
 
@@ -135,7 +142,7 @@ def run_module():
         # EXEC: query
         # execute search_software_filename first to get download link and filename
         if query:
-            download_link, download_filename = search_software_filename(query)
+            download_link, download_filename = search_software_filename(query,dedup)
 
         # execute download_software
         if dry_run:


### PR DESCRIPTION
if a filename is found many times you can add a download preferece instead of exiting with a failure to the module.

example:

    - name: download S4 Media
      community.sap_launchpad.software_center_download:
        suser_id: "{{ suser_id }}"
        suser_password: "{{ suser_password }}"
        softwarecenter_search_query: S4FND106_NW_LANG_DE.SAR
        dest: "."
        dedup: "last"
        dry_run: "{{ dryrun }}"

Options for dedup are: first, last - default is ''

This module should not break ansible compatibility but maybe direct python calls due to a change in the interface