### PR TITLE
Update sap_launchpad_software_center_download_runner.py

### DIFF
--- a/plugins/module_utils/sap_launchpad_software_center_download_runner.py
+++ b/plugins/module_utils/sap_launchpad_software_center_download_runner.py
@@ -20,7 +20,7 @@ _HAS_DOWNLOAD_AUTHORIZATION = None
 MAX_RETRY_TIMES = 3
 
 
-def search_software_filename(name, deduplicate):
+def search_software_filename(name, deduplicate=''):
     """Return a single software that matched the filename
     """
     search_results = _search_software(name)
@@ -29,15 +29,15 @@ def search_software_filename(name, deduplicate):
     if num_files == 0:
         raise ValueError(f'no result found for {name}')
     elif num_files > 1 and deduplicate == '':
-            names = [s['Title'] for s in softwares]
-            raise ValueError('more than one results were found: %s. '
-                             'please use the correct full filename' % names)
+        names = [s['Title'] for s in softwares]
+        raise ValueError('more than one results were found: %s. '
+                         'please use the correct full filename' % names)
     elif num_files > 1 and deduplicate == 'first':
-            software = softwares[0]
+        software = softwares[0]
     elif num_files > 1 and deduplicate == 'last':
-            software = softwares[num_files-1]
+        software = softwares[num_files-1]
     else:
-            software = softwares[0]
+        software = softwares[0]
     
     download_link, filename = software['DownloadDirectLink'], name
     return (download_link, filename)


### PR DESCRIPTION
added default argument value for deduplicate in search_software_file function and fixed formatting within function. This addresses issue with example for execution within python env.

```
>>> query_result = search_software_filename("HCMT_057_0-80003261.SAR")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: search_software_filename() missing 1 required positional argument: 'deduplicate'
```

https://github.com/sap-linuxlab/community.sap_launchpad/blob/main/docs/EXEC_EXAMPLES.md#execution-example-with-python-environment