### PR TITLE
Create/update systems and license keys

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: community
 name: sap_launchpad
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: 1.1.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/module_utils/constants.py
+++ b/plugins/module_utils/constants.py
@@ -6,6 +6,7 @@ URL_ACCOUNT_ATTRIBUTES = 'https://launchpad.support.sap.com/services/account/att
 URL_SERVICE_INCIDENT = 'https://launchpad.support.sap.com/services/odata/incidentws'
 URL_SERVICE_USER_ADMIN = 'https://launchpad.support.sap.com/services/odata/useradminsrv'
 URL_SOFTWARE_DOWNLOAD = 'https://softwaredownloads.sap.com'
+URL_SYSTEMS_PROVISIONING = 'https://launchpad.support.sap.com/services/odata/i7p/odata/bkey'
 # Maintainance Planner
 URL_MAINTAINANCE_PLANNER = 'https://maintenanceplanner.cfapps.eu10.hana.ondemand.com'
 URL_USERAPPS = 'https://userapps.support.sap.com/sap/support/mp/index.html'

--- a/plugins/module_utils/sap_api_common.py
+++ b/plugins/module_utils/sap_api_common.py
@@ -37,7 +37,7 @@ def _request(url, **kwargs):
     if 'allow_redirects' not in kwargs:
         kwargs['allow_redirects'] = True
 
-    method = 'POST' if kwargs.get('data') else 'GET'
+    method = 'POST' if kwargs.get('data') or kwargs.get('json') else 'GET'
     res = https_session.request(method, url, **kwargs)
     res.raise_for_status()
 

--- a/plugins/module_utils/sap_launchpad_systems_runner.py
+++ b/plugins/module_utils/sap_launchpad_systems_runner.py
@@ -248,7 +248,7 @@ def _url(query_path):
 
 
 def _headers(additional_headers):
-    return {**additional_headers, **{'Accept': 'application/json'}}
+    return {**{'Accept': 'application/json'}, **additional_headers}
 
 
 def _get_csrf_token():

--- a/plugins/module_utils/sap_launchpad_systems_runner.py
+++ b/plugins/module_utils/sap_launchpad_systems_runner.py
@@ -1,0 +1,292 @@
+from . import constants as C
+from .sap_api_common import _request
+import json
+
+from requests.exceptions import HTTPError
+
+
+class InstallationNotFoundError(Exception):
+    def __init__(self, installation_nr, available_installations):
+        self.installation_nr = installation_nr
+        self.available_installations = available_installations
+
+
+def validate_installation(installation_nr, username):
+    query_path = f"Installations?$filter=Ubname eq '{username}' and ValidateOnly eq ''"
+    installations = _request(_url(query_path), headers=_headers({})).json()['d']['results']
+    if not any(installation['Insnr'] == installation_nr for installation in installations):
+        raise InstallationNotFoundError(installation_nr, installations)
+
+
+def get_systems(filter):
+    query_path = f"Systems?$filter={filter}"
+    return _request(_url(query_path), headers=_headers({})).json()['d']['results']
+
+
+class SystemNrInvalidError(Exception):
+    def __init__(self, system_nr, details):
+        self.system_nr = system_nr
+        self.details = details
+
+
+def get_system(system_nr, installation_nr, username):
+    query_path = f"Systems?$filter=Uname eq '{username}' and Insnr eq '{installation_nr}' and Sysnr eq '{system_nr}'"
+
+    try:
+        systems = _request(_url(query_path), headers=_headers({})).json()['d']['results']
+    except HTTPError as err:
+        # in case the system is not found, the backend doesn't return an empty result set or a 404, but a 400.
+        # to make the error checking here as resilient as possible,
+        # just consider an error 400 as an invalid user error and return it to the user.
+        if err.response.status_code == 400:
+            raise SystemNrInvalidError(system_nr, err.response.content)
+        else:
+            raise err
+
+    # not sure this case ever happens; catch it nevertheless.
+    if len(systems) == 0:
+        raise SystemNrInvalidError(system_nr, "no systems returned by API")
+
+    return systems[0]
+
+
+class ProductNotFoundError(Exception):
+    def __init__(self, product, available_products):
+        self.product = product
+        self.available_products = available_products
+
+
+def get_product(product_name, installation_nr, username):
+    query_path = f"SysProducts?$filter=Uname eq '{username}' and Insnr eq '{installation_nr}' and Sysnr eq '' and Nocheck eq ''"
+    products = _request(_url(query_path), headers=_headers({})).json()['d']['results']
+    product = next((product for product in products if product['Description'] == product_name), None)
+    if product is None:
+        raise ProductNotFoundError(product_name, products)
+
+    return product['Product']
+
+
+class VersionNotFoundError(Exception):
+    def __init__(self, version, available_versions):
+        self.version = version
+        self.available_versions = available_versions
+
+
+def get_version(version_name, product_id, installation_nr, username):
+    query_path = f"SysVersions?$filter=Uname eq '{username}' and Insnr eq '{installation_nr}' and Product eq '{product_id}' and Nocheck eq ''"
+    versions = _request(_url(query_path), headers=_headers({})).json()['d']['results']
+    version = next((version for version in versions if version['Description'] == version_name), None)
+    if version is None:
+        raise VersionNotFoundError(version_name, versions)
+
+    return version['Version']
+
+
+def validate_system_data(data, version_id, system_nr, installation_nr, username):
+    query_path = f"SystData?$filter=Pvnr eq '{version_id}' and Insnr eq '{installation_nr}'"
+    results = _request(_url(query_path), headers=_headers({})).json()['d']['results'][0]
+    possible_fields = json.loads(results['Output'])
+    final_fields = _validate_user_data_against_supported_fields("system", data, possible_fields)
+
+    final_fields['Prodver'] = version_id
+    final_fields['Insnr'] = installation_nr
+    final_fields['Uname'] = username
+    final_fields['Sysnr'] = system_nr
+    final_fields = [{"name": k, "value": v} for k, v in final_fields.items()]
+    query_path = f"SystemDataCheck?$filter=Nocheck eq '' and Data eq '{json.dumps(final_fields)}'"
+    results = _request(_url(query_path), headers=_headers({})).json()['d']['results']
+
+    warning = None
+    if len(results) > 0:
+        warning = json.loads(results[0]['Data'])[0]['VALUE']
+
+    # interestingly, all downstream api calls require the names in lowercase. transform it for further usage.
+    final_fields = [{"name": entry["name"].lower(), "value": entry["value"]} for entry in final_fields]
+    return final_fields, warning
+
+
+class LicenseTypeInvalidError(Exception):
+    def __init__(self, license_type, available_license_types):
+        self.license_type = license_type
+        self.available_license_types = available_license_types
+
+
+def validate_licenses(licenses, version_id, installation_nr, username):
+    query_path = f"LicenseType?$filter=PRODUCT eq '{version_id}' and INSNR eq '{installation_nr}' and Uname eq '{username}' and Nocheck eq 'True'"
+    results = _request(_url(query_path), headers=_headers({})).json()['d']['results']
+
+    available_license_types = {result["LICENSETYPE"] for result in results}
+    license_data = []
+
+    for license in licenses:
+        result = next((result for result in results if result["LICENSETYPE"] == license['type']), None)
+        if result is None:
+            raise LicenseTypeInvalidError(license['type'], available_license_types)
+
+        final_fields = _validate_user_data_against_supported_fields(f'license {license["type"]}', license['data'],
+                                                                    json.loads(result["Selfields"]))
+        # for some reason, the API wants to have the keys in uppercase, transform it
+        final_fields = {k.upper(): v for k, v in final_fields.items()}
+        final_fields["LICENSETYPE"] = result['PRODID']
+        final_fields["LICENSETYPETEXT"] = result['LICENSETYPE']
+        license_data.append(final_fields)
+
+    return license_data
+
+
+def get_existing_licenses(system_nr, username):
+    query_path = f"LicenseKeys?$filter=Uname eq '{username}' and Sysnr eq '{system_nr}'"
+    results = _request(_url(query_path), headers=_headers({})).json()['d']['results']
+    # for some weird reason that probably only SAP knows, when updating the licenses based on the results here,
+    # they expect a completely different format. let's transform to the format the backend expects.
+    # this code most likely doesn't work for licenses that have different parameters than S4HANA or SAP HANA
+    # (which only use HWKEY, EXPDATE and QUANTITY), as I only tested it with those two license types.
+    # feel free to extend (or, even better, come up with a generic way to transform the parameters).
+    return [
+        {
+            "LICENSETYPETEXT": result["LicenseDescr"],
+            "LICENSETYPE": result["Prodid"],
+            "HWKEY": result["Hwkey"],
+            "EXPDATE": result["LidatC"],
+            "STATUS": result["Status"],
+            "STATUSCODE": result["StatusCode"],
+            "KEYNR": result["Keynr"],
+            "QUANTITY": result["Ulimit"],
+            "QUANTITY_C": result["UlimitC"],
+            "MAXEXPDATE": result["MaxLiDat"]
+        } for result in results
+    ]
+
+
+def keep_only_new_or_changed_licenses(existing_licenses, license_data):
+    new_or_changed_licenses = []
+    for license in license_data:
+        if not any(license['HWKEY'] == lic['HWKEY'] and license['LICENSETYPE'] == lic['LICENSETYPE'] for lic in
+                   existing_licenses):
+            new_or_changed_licenses.append(license)
+
+    return new_or_changed_licenses
+
+
+def generate_licenses(license_data, existing_licenses, version_id, installation_nr, username):
+    body = {
+        "Prodver": version_id,
+        "ActionCode": "add",
+        "ExistingData": json.dumps(existing_licenses),
+        "Entry": json.dumps(license_data),
+        "Nocheck": "",
+        "Insnr": installation_nr,
+        "Uname": username
+    }
+    response = _request(_url("BSHWKEY"), json=body, headers=_headers({'x-csrf-token': _get_csrf_token()})).json()
+    return json.loads(response['d']['Result'])
+
+
+def submit_system(is_new, system_data, generated_licenses, username):
+    body = {
+        "actcode": "add" if is_new else "edit",
+        "Uname": username,
+        "sysdata": json.dumps(system_data),
+        "matdata": json.dumps(
+            # again, SAP Backend requires a completely different format than it returned. let's map it.
+            # this code most likely doesn't work for licenses that have different parameters than S4HANA or SAP HANA
+            # (which only use HWKEY, EXPDATE and QUANTITY), as I only tested it with those two license types.
+            # feel free to extend (or, even better, come up with a generic way to transform the parameters).
+            [
+                {
+                    "hwkey": license["HWKEY"],
+                    "prodid": license["LICENSETYPE"],
+                    "quantity": license["QUANTITY"],
+                    "keynr": license["KEYNR"],
+                    "expdat": license["EXPDATE"],
+                    "status": license["STATUS"],
+                    "statusCode": license["STATUSCODE"],
+                } for license in generated_licenses
+            ]
+        )
+    }
+    response = _request(_url("Submit"), json=body, headers=_headers({'x-csrf-token': _get_csrf_token()})).json()
+    return json.loads(response['d']['licdata'])[0]['VALUE']  # contains system number
+
+
+def get_license_key_numbers(license_data, system_nr, username):
+    key_nrs = []
+    for license in license_data:
+        query_path = f"LicenseKeys?$filter=Uname eq '{username}' and Sysnr eq '{system_nr}' and Prodid eq '{license['LICENSETYPE']}' and Hwkey eq '{license['HWKEY']}'"
+        results = _request(_url(query_path), headers=_headers({})).json()['d']['results']
+        key_nrs.append(results[0]['Keynr'])
+
+    return key_nrs
+
+
+def download_licenses(key_nrs):
+    keys_json = json.dumps([{"Keynr": key_nr} for key_nr in key_nrs])
+    return _request(_url(f"FileContent(Keynr='{keys_json}')/$value")).content
+
+
+def find_licenses_to_delete(key_nrs_to_keep, existing_licenses):
+    return [existing_license for existing_license in existing_licenses if
+            not existing_license['KEYNR'] in key_nrs_to_keep]
+
+
+def delete_licenses(licenses_to_delete, existing_licenses, version_id, installation_nr, username):
+    body = {
+        "Prodver": version_id,
+        "ActionCode": "delete",
+        "ExistingData": json.dumps(existing_licenses),
+        "Entry": json.dumps(licenses_to_delete),
+        "Nocheck": "",
+        "Insnr": installation_nr,
+        "Uname": username
+    }
+    response = _request(_url("BSHWKEY"), json=body, headers=_headers({'x-csrf-token': _get_csrf_token()})).json()
+    return json.loads(response['d']['Result'])
+
+
+def _url(query_path):
+    return f'{C.URL_SYSTEMS_PROVISIONING}/{query_path}'
+
+
+def _headers(additional_headers):
+    return {**additional_headers, **{'Accept': 'application/json'}}
+
+
+def _get_csrf_token():
+    return _request(C.URL_SYSTEMS_PROVISIONING, headers=_headers({'x-csrf-token': 'Fetch'})).headers['x-csrf-token']
+
+
+class DataInvalidError(Exception):
+    def __init__(self, scope, unknown_fields, missing_required_fields, fields_with_invalid_option):
+        self.scope = scope
+        self.unknown_fields = unknown_fields
+        self.missing_required_fields = missing_required_fields
+        self.fields_with_invalid_option = fields_with_invalid_option
+
+
+def _validate_user_data_against_supported_fields(scope, user_data, possible_fields):
+    unknown_fields = {field for field, _ in user_data.items() if
+                      not any(field == possible_field['FIELD'] for possible_field in possible_fields)}
+    missing_required_fields = {}
+    fields_with_invalid_option = {}
+    final_fields = {}
+
+    for possible_field in possible_fields:
+        user_value = user_data.get(possible_field["FIELD"])
+        if user_value is not None:  # user has provided a value for this field
+            if len(possible_field["DATA"]) == 0:  # there are no options for these fields = all inputs are ok.
+                final_fields[possible_field["FIELD"]] = user_value
+
+            else:  # there are options for these fields - resolve their values by their description
+                resolved_value = next(
+                    (entry["NAME"] for entry in possible_field["DATA"] if entry['VALUE'] == user_value), None)
+                if resolved_value is None:
+                    fields_with_invalid_option[possible_field["FIELD"]] = possible_field["DATA"]
+                else:
+                    final_fields[possible_field["FIELD"]] = resolved_value
+        elif possible_field['REQUIRED'] == "X":  # missing required field
+            missing_required_fields[possible_field["FIELD"]] = possible_field["DATA"]
+
+    if len(unknown_fields) > 0 or len(missing_required_fields) > 0 or len(fields_with_invalid_option) > 0:
+        raise DataInvalidError(scope, unknown_fields, missing_required_fields, fields_with_invalid_option)
+
+    return final_fields

--- a/plugins/modules/license_keys.py
+++ b/plugins/modules/license_keys.py
@@ -39,10 +39,6 @@ def run_module():
         supports_check_mode=False
     )
 
-    # Check mode
-    if module.check_mode:
-        module.exit_json(**result)
-
     username = module.params.get('suser_id')
     password = module.params.get('suser_password')
     installation_nr = module.params.get('installation_nr')

--- a/plugins/modules/license_keys.py
+++ b/plugins/modules/license_keys.py
@@ -1,0 +1,143 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils.sap_launchpad_systems_runner import *
+from ..module_utils.sap_id_sso import sap_sso_login
+
+
+def run_module():
+    # Define available arguments/parameters a user can pass to the module
+    module_args = dict(
+        suser_id=dict(type='str', required=True),
+        suser_password=dict(type='str', required=True, no_log=True),
+        installation_nr=dict(type='str', required=True),
+        system=dict(
+            type='dict',
+            options=dict(
+                nr=dict(type='str', required=False),
+                product=dict(type='str', required=True),
+                version=dict(type='str', required=True),
+                data=dict(type='dict')
+            )
+        ),
+        licenses=dict(type='list', required=True, elements='dict', options=dict(
+            type=dict(type='str', required=True),
+            data=dict(type='dict'),
+        )),
+        delete_other_licenses=dict(type='bool', required=False, default=False),
+    )
+
+    # Define result dictionary objects to be passed back to Ansible
+    result = dict(
+        license_file='',
+        changed=False,
+        msg=''
+    )
+
+    # Instantiate module
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    # Check mode
+    if module.check_mode:
+        module.exit_json(**result)
+
+    username = module.params.get('suser_id')
+    password = module.params.get('suser_password')
+    installation_nr = module.params.get('installation_nr')
+    system = module.params.get('system')
+    system_nr = system.get('nr')
+    product = system.get('product')
+    version = system.get('version')
+    data = system.get('data')
+    licenses = module.params.get('licenses')
+
+    if len(licenses) == 0:
+        module.fail_json("licenses cannot be empty")
+
+    delete_other_licenses = module.params.get('delete_other_licenses')
+
+    sap_sso_login(username, password)
+
+    try:
+        validate_installation(installation_nr, username)
+    except InstallationNotFoundError as err:
+        module.fail_json("Installation could not be found", installation_nr=err.installation_nr,
+                         available_installations=[inst['Text'] for inst in err.available_installations])
+
+    existing_system = None
+    if system_nr is not None:
+        try:
+            existing_system = get_system(system_nr, installation_nr, username)
+        except SystemNrInvalidError as err:
+            module.fail_json("System could not be found", system_nr=err.system_nr, details=err.details)
+
+    product_id = None
+    try:
+        product_id = get_product(product, installation_nr, username)
+    except ProductNotFoundError as err:
+        module.fail_json("Product could not be found", product=err.product,
+                         available_products=[product['Description'] for product in err.available_products])
+
+    version_id = None
+    try:
+        version_id = get_version(version, product_id, installation_nr, username)
+    except VersionNotFoundError as err:
+        module.fail_json("Version could not be found", version=err.version,
+                         available_versions=[version['Description'] for version in err.available_versions])
+
+    system_data = None
+    try:
+        system_data, warning = validate_system_data(data, version_id, system_nr, installation_nr, username)
+        if warning is not None:
+            module.warn(warning)
+    except DataInvalidError as err:
+        module.fail_json(f"Invalid {err.scope} data",
+                         unknown_fields=err.unknown_fields,
+                         missing_required_fields=err.missing_required_fields,
+                         fields_with_invalid_option=err.fields_with_invalid_option)
+
+    license_data = None
+    try:
+        license_data = validate_licenses(licenses, version_id, installation_nr, username)
+    except LicenseTypeInvalidError as err:
+        module.fail_json(f"Invalid license type", license_type=err.license_type, available_license_types=err.available_license_types)
+    except DataInvalidError as err:
+        module.fail_json(f"Invalid {err.scope} data",
+                         unknown_fields=err.unknown_fields,
+                         missing_required_fields=err.missing_required_fields,
+                         fields_with_invalid_option=err.fields_with_invalid_option)
+
+    generated_licenses = []
+    existing_licenses = []
+    new_or_changed_license_data = license_data
+
+    if existing_system is not None:
+        existing_licenses = get_existing_licenses(system_nr, username)
+        new_or_changed_license_data = keep_only_new_or_changed_licenses(existing_licenses, license_data)
+
+    if len(new_or_changed_license_data) > 0:
+        generated_licenses = generate_licenses(new_or_changed_license_data, existing_licenses, version_id,
+                                               installation_nr, username)
+
+    system_nr = submit_system(existing_system is None, system_data, generated_licenses, username)
+    key_nrs = get_license_key_numbers(license_data, system_nr, username)
+    result['license_file'] = download_licenses(key_nrs)
+
+    if delete_other_licenses:
+        existing_licenses = get_existing_licenses(system_nr, username)
+        licenses_to_delete = find_licenses_to_delete(key_nrs, existing_licenses)
+        if len(licenses_to_delete) > 0:
+            updated_licenses = delete_licenses(licenses_to_delete, existing_licenses, version_id, installation_nr, username)
+            submit_system(False, system_data, updated_licenses, username)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/systems_info.py
+++ b/plugins/modules/systems_info.py
@@ -5,24 +5,70 @@ from ..module_utils.sap_id_sso import sap_sso_login
 
 from requests.exceptions import HTTPError
 
-# TODO document
+DOCUMENTATION = r'''
+---
+module: systems_info
+
+short_description: Queries registered systems in me.sap.com
+
+version_added: 1.1.0
+
+options:
+  suser_id:
+    description:
+      - SAP S-User ID.
+    required: true
+    type: str
+  suser_password:
+    description:
+      - SAP S-User Password.
+    required: true
+    type: str
+  filter:
+    description:
+      - An ODATA filter expression to query the systems.
+    required: true
+    type: str
+author:
+    - Lab for SAP Solutions
+
+'''
+
+
+EXAMPLES = r'''
+- name: get system by SID and product
+  community.sap_launchpad.systems_info:
+    suser_id: 'SXXXXXXXX'
+    suser_password: 'password'
+    filter: "Insnr eq '12345678' and sysid eq 'H01' and ProductDescr eq 'SAP S/4HANA'"
+  register: result
+
+- name: Display the first returned system
+  debug:
+    msg:
+      - "{{ result.systems[0] }}"
+'''
+
+
+RETURN = r'''
+systems:
+  description: the systems returned for the filter
+  returned: always
+  type: list
+'''
+
 
 def run_module():
-
-    # Define available arguments/parameters a user can pass to the module
     module_args = dict(
         suser_id=dict(type='str', required=True),
         suser_password=dict(type='str', required=True, no_log=True),
         filter=dict(type='str', required=True),
     )
 
-    # Define result dictionary objects to be passed back to Ansible
     result = dict(
         systems='',
-        changed=False,
     )
 
-    # Instantiate module
     module = AnsibleModule(
         argument_spec=module_args,
         supports_check_mode=False

--- a/plugins/modules/systems_info.py
+++ b/plugins/modules/systems_info.py
@@ -5,6 +5,7 @@ from ..module_utils.sap_id_sso import sap_sso_login
 
 from requests.exceptions import HTTPError
 
+# TODO document
 
 def run_module():
 

--- a/plugins/modules/systems_info.py
+++ b/plugins/modules/systems_info.py
@@ -27,10 +27,6 @@ def run_module():
         supports_check_mode=False
     )
 
-    # Check mode
-    if module.check_mode:
-        module.exit_json(**result)
-
     username = module.params.get('suser_id')
     password = module.params.get('suser_password')
     filter = module.params.get('filter')

--- a/plugins/modules/systems_info.py
+++ b/plugins/modules/systems_info.py
@@ -1,0 +1,54 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils.sap_launchpad_systems_runner import *
+from ..module_utils.sap_id_sso import sap_sso_login
+
+from requests.exceptions import HTTPError
+
+
+def run_module():
+
+    # Define available arguments/parameters a user can pass to the module
+    module_args = dict(
+        suser_id=dict(type='str', required=True),
+        suser_password=dict(type='str', required=True, no_log=True),
+        filter=dict(type='str', required=True),
+    )
+
+    # Define result dictionary objects to be passed back to Ansible
+    result = dict(
+        systems='',
+        changed=False,
+    )
+
+    # Instantiate module
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    # Check mode
+    if module.check_mode:
+        module.exit_json(**result)
+
+    username = module.params.get('suser_id')
+    password = module.params.get('suser_password')
+    filter = module.params.get('filter')
+
+    sap_sso_login(username, password)
+
+    try:
+        result["systems"] = get_systems(filter)
+    except HTTPError as err:
+        module.fail_json("Error while querying systems", status_code=err.response.status_code,
+                         response=err.response.content)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds the functionality discussed in issue https://github.com/sap-linuxlab/community.sap_launchpad/issues/15.

## Scope
- The PR adds two modules:
  - `license_keys`, which allows creating and updating systems and their license keys.
    It is closely modeled after the interactions in the portal <https://me.sap.com/licensekey>, meaning that systems and license keys are always updated together (i.e. you cannot just create new license keys, but you have to edit the system, add license keys, and submit everything together).
  - `systems_info`, which allows retrieving existing systems (i.e. its system number), so that the system update/license key creation can be done in an idempotent manner (see example below). 
-  What is intentionally out of scope:
    - The entity 'Installation' - the parent entity of systems - has to be created manually beforehand (and its installation number passed on to the module). We think that it's not worth to offer automation for creating installations, as installations are usually created once per customer and only the systems and license keys change frequently.
    - The module doesn't allow deletion of systems or license keys. We found that decommissioning of SAP systems is usually a manual process anyway. But if desired, we can add deletion to this module/PR.

## Example

An example usage of the module which allows to idempotently create or update a system and retrieve the license key file:

```
- name: test license key creation
  hosts: localhost
  tasks:

  - name: get existing system
    community.sap_launchpad.systems_info:
      suser_id: S1234
      suser_password: password
      filter: "Insnr eq '123456789' and sysid eq 'B01' and ProductDescr eq 'SAP S/4HANA'"
    register: result

  - name: create license keys
    community.sap_launchpad.license_keys:
      suser_id: S1234
      suser_password: password
      installation_nr: 123456789
      system:
        nr: "{{ result.systems[0].Sysnr | default(omit) }}"
        product: SAP S/4HANA
        version: SAP S/4HANA 2022
        data:
          sysid: B01
          sysname: Test-System
          systype: Development system
          sysdb: SAP HANA database
          sysos: Linux
          sys_depl: Public - Microsoft Azure
      licenses:
        - type: Standard - Web Application Server ABAP or ABAP+JAVA
          data:
            hwkey: H1234567890
            expdate: 99991231
        - type: Maintenance Entitlement
          data:
            hwkey: H1234567890
            expdate: 99991231
    register: result

  - name: Display the license file containing the licenses
    debug:
      msg:
        - "{{ result.license_file }}"

```

I tested the following use cases to ensure full idempotency.

- If no system exists, a new system and its licenses are created
- If a system exists and passed with `system.nr`, its data attributes are updated and any changed licenses applied. If the licenses had no changes, they are not updated.

Let me know if you need more examples (should we create a sample playbook in the repo?), more extensive documentation or other changes. Please also let me know if I have to sign any CLA. Eager to get your feedback!
