### PR TITLE
align headers, clean up imports & fix typo

### DIFF
--- a/plugins/module_utils/constants.py
+++ b/plugins/module_utils/constants.py
@@ -6,8 +6,8 @@ URL_ACCOUNT_ATTRIBUTES = 'https://launchpad.support.sap.com/services/account/att
 URL_SERVICE_INCIDENT = 'https://launchpad.support.sap.com/services/odata/incidentws'
 URL_SERVICE_USER_ADMIN = 'https://launchpad.support.sap.com/services/odata/useradminsrv'
 URL_SOFTWARE_DOWNLOAD = 'https://softwaredownloads.sap.com'
-# Maintainance Planner
-URL_MAINTAINANCE_PLANNER = 'https://maintenanceplanner.cfapps.eu10.hana.ondemand.com'
+# Maintenance Planner
+URL_MAINTENANCE_PLANNER = 'https://maintenanceplanner.cfapps.eu10.hana.ondemand.com'
 URL_USERAPPS = 'https://userapps.support.sap.com/sap/support/mp/index.html'
 URL_USERAPP_MP_SERVICE = 'https://userapps.support.sap.com/sap/support/mnp/services'
 URL_LEGACY_MP_API = 'https://tech.support.sap.com/sap/support/mnp/services'

--- a/plugins/module_utils/sap_api_common.py
+++ b/plugins/module_utils/sap_api_common.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# coding: utf-8
-
 import logging
 import re
 from urllib.parse import urlparse

--- a/plugins/module_utils/sap_id_sso.py
+++ b/plugins/module_utils/sap_id_sso.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# coding: utf-8
-
 import json
 import logging
 import re

--- a/plugins/module_utils/sap_launchpad_maintenance_planner_runner.py
+++ b/plugins/module_utils/sap_launchpad_maintenance_planner_runner.py
@@ -1,7 +1,3 @@
-#!/user/bin/env python3
-# coding: utf-8
-
-import os
 import pathlib
 import re
 import time
@@ -11,11 +7,10 @@ from urllib.parse import urljoin
 from bs4 import BeautifulSoup
 from lxml import etree
 from requests.auth import HTTPBasicAuth
-from requests.sessions import session
 
 from . import constants as C
 from .sap_api_common import _request, https_session
-from .sap_id_sso import _get_sso_endpoint_meta, sap_sso_login
+from .sap_id_sso import _get_sso_endpoint_meta
 
 _MP_XSRF_TOKEN = None
 _MP_TRANSACTIONS = None
@@ -24,7 +19,7 @@ _MP_TRANSACTIONS = None
 def auth_maintenance_planner():
     # Clear mp relevant cookies for avoiding unexpected responses.
     _clear_mp_cookies('maintenanceplanner')
-    res = _request(C.URL_MAINTAINANCE_PLANNER)
+    res = _request(C.URL_MAINTENANCE_PLANNER)
     sig_re = re.compile('signature=(.*?);path=\/";location="(.*)"')
     signature, redirect = re.search(sig_re, res.text).groups()
 
@@ -35,7 +30,7 @@ def auth_maintenance_planner():
         'locationAfterLogin': '%2F'
     }
 
-    MP_DOMAIN = C.URL_MAINTAINANCE_PLANNER.replace('https://', '')
+    MP_DOMAIN = C.URL_MAINTENANCE_PLANNER.replace('https://', '')
     for k, v in mp_cookies.items():
         https_session.cookies.set(k, v, domain=MP_DOMAIN, path='/')
 
@@ -68,7 +63,7 @@ def auth_userapps():
 
 
 def get_mp_user_details():
-    url = urljoin(C.URL_MAINTAINANCE_PLANNER,
+    url = urljoin(C.URL_MAINTENANCE_PLANNER,
                   '/MCP/MPHomePageController/getUserDetailsDisplay')
     params = {'_': int(time.time() * 1000)}
     user = _request(url, params=params).json()

--- a/plugins/module_utils/sap_launchpad_software_center_catalog_runner.py
+++ b/plugins/module_utils/sap_launchpad_software_center_catalog_runner.py
@@ -1,9 +1,5 @@
-#!/user/bin/env python3
-# coding: utf-8
-
 from . import constants as C
 from .sap_api_common import _request
-from .sap_id_sso import sap_sso_login
 
 
 def get_software_catalog():

--- a/plugins/module_utils/sap_launchpad_software_center_download_runner.py
+++ b/plugins/module_utils/sap_launchpad_software_center_download_runner.py
@@ -1,6 +1,3 @@
-#!/user/bin/env python3
-# coding: utf-8
-
 import hashlib
 import json
 import logging
@@ -12,7 +9,7 @@ from requests.exceptions import HTTPError
 
 from . import constants as C
 from .sap_api_common import _request, https_session
-from .sap_id_sso import _get_sso_endpoint_meta, sap_sso_login
+from .sap_id_sso import _get_sso_endpoint_meta
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/module_utils/sap_launchpad_software_center_download_search_fuzzy.py
+++ b/plugins/module_utils/sap_launchpad_software_center_download_search_fuzzy.py
@@ -5,7 +5,6 @@ import requests
 
 from . import constants as C
 from .sap_api_common import _request
-from .sap_id_sso import sap_sso_login
 
 
 def search_software_fuzzy(query, max=None, csv_filename=None):

--- a/plugins/modules/maintenance_planner_files.py
+++ b/plugins/modules/maintenance_planner_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # SAP Maintenance Planner files retrieval
 
@@ -69,6 +69,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ..module_utils.sap_launchpad_maintenance_planner_runner import *
 from ..module_utils.sap_launchpad_software_center_download_runner import \
     is_download_link_available
+from ..module_utils.sap_id_sso import sap_sso_login
 
 
 def run_module():

--- a/plugins/modules/maintenance_planner_stack_xml_download.py
+++ b/plugins/modules/maintenance_planner_stack_xml_download.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # SAP Maintenance Planner Stack XML download
 
@@ -69,6 +69,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 # Import runner
 from ..module_utils.sap_launchpad_maintenance_planner_runner import *
+from ..module_utils.sap_id_sso import sap_sso_login
 
 
 def run_module():

--- a/plugins/modules/software_center_download.py
+++ b/plugins/modules/software_center_download.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # SAP software download module
 
@@ -88,6 +88,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 # Import runner
 from ..module_utils.sap_launchpad_software_center_download_runner import *
+from ..module_utils.sap_id_sso import sap_sso_login
 
 
 def run_module():


### PR DESCRIPTION
Hi folks

As discussed with @rainerleber in https://github.com/sap-linuxlab/community.sap_launchpad/pull/16#discussion_r1386496873, the file headers are in need of some alignment ;)

This PR does the following:

- remove any encoding header since [they are not needed with python 3](https://stackoverflow.com/a/56118631) (do we need to support python 2 still?)
- remove any shebangs in the module_utils, add them to modules (only these are invoked directly)

Along the way I fixed a typo and arranged some imports - see inline comments.