### PR TITLE
Added check for MFA

### DIFF
--- a/plugins/module_utils/sap_api_common.py
+++ b/plugins/module_utils/sap_api_common.py
@@ -41,6 +41,9 @@ def _request(url, **kwargs):
             and res.json()['errorMessage'].startswith('Account Temporarily Locked Out')):
         raise Exception('SAP ID Service has reported `Account Temporarily Locked Out`. Please reset password to regain access and try again.')
 
+    if "WEB Two-Factor Authentication" in str(res.content):
+        raise Exception('The SAP ID is enabled for two-factor authentication (MFA). Please disable MFA under https://accounts.sap.com/ and try again.')
+
     res.raise_for_status()
 
     return res


### PR DESCRIPTION
If the S-User has MFA activated, it is not possible to use it for download. I added a check in _request to check if "WEB Two-Factor Authentication" is in the content of the web request.

```
TASK [Execute Ansible Module to download SAP software] ***********************************************************************************************************
FAILED - RETRYING: [10.230.248.85]: Execute Ansible Module to download SAP software (1 retries left).
failed: [10.230.248.85] (item=SAPCAR_1200-70007716.EXE : An exception has occurred - The SAP ID is enabled for two-factor authentication (MFA). Please disable MFA under https://accounts.sap.com/ for the user and try again.) => {"ansible_loop_var": "item", "attempts": 1, "changed": false, "item": "SAPCAR_1200-70007716.EXE", "msg": "An exception has occurred - The SAP ID is enabled for two-factor authentication (MFA). Please disable MFA under https://accounts.sap.com/ for the user and try again."}
```