### PR TITLE
maintenance_planner modules: Add option to use Display ID instead of name

### DIFF
--- a/plugins/module_utils/sap_launchpad_maintenance_planner_runner.py
+++ b/plugins/module_utils/sap_launchpad_maintenance_planner_runner.py
@@ -281,6 +281,26 @@ def _get_transaction_name(trans_id):
     return transaction['trans_name']
 
 
+def get_transaction_id(name):
+    """
+    Search transaction ID using transaction Name or Display ID.
+    
+    Args:
+        name: transaction name or display id.
+    """
+    transactions = get_transactions()
+    transaction_name = [t for t in transactions if t['trans_name'] == name]
+    if not transaction_name:
+        # Repeat search using Display ID
+        transaction_display_id = [t for t in transactions if t['trans_display_id'] == name]
+        if not transaction_display_id:
+            raise KeyError(f'Name or Display ID {name} not found in transactionsX')
+        else:
+            return transaction_display_id[0]['trans_id']
+    else:
+        return transaction_name[0]['trans_id']
+
+
 def _get_transaction(key, value):
     transactions = get_transactions()
     trans = [t for t in transactions if t[key] == value]

--- a/plugins/modules/maintenance_planner_files.py
+++ b/plugins/modules/maintenance_planner_files.py
@@ -27,11 +27,11 @@ options:
     type: str
   transaction_name:
     description:
-      - Transaction name of your Maintenance Planner session.
+      - Name or Display ID of your Maintenance Planner transaction.
     required: true
     type: str
 author:
-    - Lab for SAP Solutions
+    - SAP LinuxLab
 
 '''
 
@@ -115,7 +115,7 @@ def run_module():
         auth_userapps()
 
         # EXEC: Get MP stack transaction id from transaction name
-        transaction_id = get_transaction_id_by_name(transaction_name)
+        transaction_id = get_transaction_id(transaction_name)
 
         # EXEC: Get a json list of download_links and download_filenames
         download_basket_details = get_transaction_filename_url(transaction_id)

--- a/plugins/modules/maintenance_planner_stack_xml_download.py
+++ b/plugins/modules/maintenance_planner_stack_xml_download.py
@@ -27,16 +27,16 @@ options:
     type: str
   transaction_name:
     description:
-      - Transaction name of your Maintenance Planner session.
+      - Name or Display ID of your Maintenance Planner transaction.
     required: true
     type: str
-  dest:
+  download_path:
     description:
-      - Destination folder.
+      - Destination folder path.
     required: true
     type: str
 author:
-    - Lab for SAP Solutions
+    - SAP LinuxLab
 
 '''
 
@@ -46,7 +46,7 @@ EXAMPLES = r'''
     suser_id: 'SXXXXXXXX'
     suser_password: 'password'
     transaction_name: 'MP_NEW_INST_20211015_044854'
-    dest: "/tmp/"
+    download_path: "/tmp/"
   register: sap_mp_register
 - name: Display the list of download links and filenames
   debug:
@@ -79,7 +79,7 @@ def run_module():
         suser_id=dict(type='str', required=True),
         suser_password=dict(type='str', required=True, no_log=True),
         transaction_name=dict(type='str', required=True),
-        dest=dict(type='str', required=True)
+        download_path=dict(type='str', required=True)
     )
 
     # Define result dictionary objects to be passed back to Ansible
@@ -102,7 +102,7 @@ def run_module():
     username = module.params.get('suser_id')
     password = module.params.get('suser_password')
     transaction_name = module.params.get('transaction_name')
-    dest = module.params.get('dest')
+    download_path = module.params.get('download_path')
 
     # Main run
 
@@ -115,10 +115,10 @@ def run_module():
         auth_userapps()
 
         # EXEC: Get MP stack transaction id from transaction name
-        transaction_id = get_transaction_id_by_name(transaction_name)
+        transaction_id = get_transaction_id(transaction_name)
 
         # EXEC: Download the MP Stack XML file
-        get_transaction_stack_xml(transaction_id, dest)
+        get_transaction_stack_xml(transaction_id, download_path)
 
         # Process return dictionary for Ansible
         result['changed'] = True


### PR DESCRIPTION
## Description
Transaction Display ID is always unique and our modules were not using it. This PR adds new function that searches transaction using Name and it will attempt search using Display ID if it finds nothing for Name.

https://github.com/sap-linuxlab/community.sap_launchpad/issues/25

## Changes
- New function `get_transaction_id` that does one API call instead of 2 that using `get_transaction_id_by_name`  along with `get_transaction_id_by_display_id` would do.
- `dest` arg in module `maintenance_planner_stack_xml_download` was renamed to `download_path` to align it with breaking changes in #28 
 