### PR TITLE
sap_software_download: Update for ansible-core 2.19

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Ansible Lint Action
-      uses: ansible-community/ansible-lint-action@v6.0.2
+      uses: ansible/ansible-lint@v6

--- a/roles/sap_software_download/tasks/pre_steps/05_validate_relations.yml
+++ b/roles/sap_software_download/tasks/pre_steps/05_validate_relations.yml
@@ -71,8 +71,10 @@
 
 - name: Relationship Validation - Define list of files
   ansible.builtin.set_fact:
-    __sap_software_download_files: "{{ sap_software_download_files if not sap_software_download_find_alternatives
-      else __sap_software_download_files_results_dryrun.results | selectattr('failed', 'false')| map(attribute='filename') | list | unique | d([])}}"
+    __sap_software_download_files:
+      "{{ sap_software_download_files
+        if not sap_software_download_find_alternatives
+        else __sap_software_download_files_results_dryrun.results | selectattr('failed', 'false') | map(attribute='filename') | list | unique | d([]) }}"
 
 
 - name: Relationship Validation - SAP HANA - Multiple IMDB_SERVER files found

--- a/roles/sap_software_download/vars/SLES_15.yml
+++ b/roles/sap_software_download/vars/SLES_15.yml
@@ -25,21 +25,22 @@ __sap_software_download_python_package: >-
 
 # The list of required Python Modules in packages
 # This is required in order to avoid externally-managed-environment error.
-__sap_software_download_python_module_packages: >-
-    {%- if ansible_distribution_version.split('.')[1] | int < 5 -%}
-    [
-      "python3-wheel",
-      "python3-urllib3",
-      "python3-requests",
-      "python3-beautifulsoup4",
-      "python3-lxml"
-    ]
-    {%- else -%}
-    [
-      "python311-wheel",
-      "python311-urllib3",
-      "python311-requests",
-      "python311-beautifulsoup4",
-      "python311-lxml"
-    ]
-    {%- endif -%}
+__sap_software_download_python_module_packages:
+    "{{ __sap_software_download_python_module_packages_3
+      if ansible_distribution_version.split('.')[1] | int < 5
+      else __sap_software_download_python_module_packages_311 }}"
+
+# The lists of Python Modules for specific python version
+__sap_software_download_python_module_packages_3:
+  - "python3-wheel"
+  - "python3-urllib3"
+  - "python3-requests"
+  - "python3-beautifulsoup4"
+  - "python3-lxml"
+
+__sap_software_download_python_module_packages_311:
+  - "python311-wheel"
+  - "python311-urllib3"
+  - "python311-requests"
+  - "python311-beautifulsoup4"
+  - "python311-lxml"

--- a/roles/sap_software_download/vars/SLES_15.yml
+++ b/roles/sap_software_download/vars/SLES_15.yml
@@ -26,9 +26,9 @@ __sap_software_download_python_package: >-
 # The list of required Python Modules in packages
 # This is required in order to avoid externally-managed-environment error.
 __sap_software_download_python_module_packages:
-    "{{ __sap_software_download_python_module_packages_3
-      if ansible_distribution_version.split('.')[1] | int < 5
-      else __sap_software_download_python_module_packages_311 }}"
+  "{{ __sap_software_download_python_module_packages_3
+    if ansible_distribution_version.split('.')[1] | int < 5
+    else __sap_software_download_python_module_packages_311 }}"
 
 # The lists of Python Modules for specific python version
 __sap_software_download_python_module_packages_3:


### PR DESCRIPTION
## Reason
Details about upcoming ansible-core 2.19 are listed in https://github.com/sap-linuxlab/community.sap_launchpad/issues/48

## Changes
`ansible-core 2.19` does not process jinja2 vars same way, translating all of them into String regardless of type defined inside of jinja.
- This change will change jinja2 code building list into jinja2 selecting list, which will retain list type.

- Update linting action and solve linting errors