### PR TITLE
sap_software_download: Fix for failed checksums not correctly retrying

### DIFF
--- a/roles/sap_software_download/tasks/download_files.yml
+++ b/roles/sap_software_download/tasks/download_files.yml
@@ -14,8 +14,6 @@
   loop_control:
     label: "{{ item }} : {{ __sap_software_download_files_results_venv.msg | d('') }}"
   register: __sap_software_download_files_results_venv
-  retries: 1
-  until: __sap_software_download_files_results_venv is not failed
   environment:
     PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_env.PATH }}"
     PYTHONPATH: "{{ __sap_software_download_venv.path }}/lib/{{ sap_software_download_python_interpreter }}/site-packages"
@@ -38,8 +36,6 @@
   loop_control:
     label: "{{ item }} : {{ __sap_software_download_files_results_default.msg | d('') }}"
   register: __sap_software_download_files_results_default
-  retries: 1
-  until: __sap_software_download_files_results_default is not failed
   vars:
     ansible_python_interpreter: "{{ '/usr/bin/' ~ sap_software_download_python_interpreter }}"
   ignore_errors: true  # Errors are ignored and validated afterwards

--- a/roles/sap_software_download/tasks/download_plan.yml
+++ b/roles/sap_software_download/tasks/download_plan.yml
@@ -13,8 +13,6 @@
   loop_control:
     label: "{{ item.Filename }} : {{ __sap_software_download_files_plan_results_venv.msg | d('') }}"
   register: __sap_software_download_files_plan_results_venv
-  retries: 1
-  until: __sap_software_download_files_plan_results_venv is not failed
   environment:
     PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_env.PATH }}"
     PYTHONPATH: "{{ __sap_software_download_venv.path }}/lib/{{ sap_software_download_python_interpreter }}/site-packages"
@@ -36,8 +34,6 @@
   loop_control:
     label: "{{ item.Filename }} : {{ __sap_software_download_files_plan_results_default.msg | d('') }}"
   register: __sap_software_download_files_plan_results_default
-  retries: 1
-  until: __sap_software_download_files_plan_results_default is not failed
   vars:
     ansible_python_interpreter: "{{ '/usr/bin/' ~ sap_software_download_python_interpreter }}"
   ignore_errors: true  # Errors are ignored and validated afterwards

--- a/roles/sap_software_download/tasks/download_stack.yml
+++ b/roles/sap_software_download/tasks/download_stack.yml
@@ -9,7 +9,6 @@
     transaction_name: "{{ sap_software_download_mp_transaction }}"
     dest: "{{ sap_software_download_directory }}"
   register: __sap_software_download_stack_results_venv
-  retries: 1
   environment:
     PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_env.PATH }}"
     PYTHONPATH: "{{ __sap_software_download_venv.path }}/lib/{{ sap_software_download_python_interpreter }}/site-packages"
@@ -27,7 +26,6 @@
     transaction_name: "{{ sap_software_download_mp_transaction }}"
     dest: "{{ sap_software_download_directory }}"
   register: __sap_software_download_stack_results_default
-  retries: 1
   vars:
     ansible_python_interpreter: "{{ '/usr/bin/' ~ sap_software_download_python_interpreter }}"
   ignore_errors: true  # Errors are ignored and validated afterwards


### PR DESCRIPTION
## Issue
Issue was detected when downloads were interrupted, which resulted in retry attempt detecting partial file and skipping it.
https://github.com/sap-linuxlab/community.sap_launchpad/issues/39

Root cause:
- Function `_download_file` was not deleting partial files (failed checksum) at correct point in time
- Role detected failure because of checksum, retried running module, which detected file that was not deleted resulting in success.

## Changes
- Move up deletion of file outside of retry conditional
- Remove retry parameters in role tasks