### PR TITLE
all: Replace inject vars with ansible_facts for 2.20

### DIFF
--- a/docs/module_license_keys.md
+++ b/docs/module_license_keys.md
@@ -230,7 +230,7 @@ Install prerequisites and create new SAP system using existing Python Virtual En
         download_path: "/tmp/licenses"
       register: result
       environment:
-        PATH: "/tmp/python_venv:{{ ansible_env.PATH }}" 
+        PATH: "/tmp/python_venv:{{ ansible_facts['env'].PATH }}" 
         PYTHONPATH: "/tmp/python_venv/lib/python3.11/site-packages" 
         VIRTUAL_ENV: "/tmp/python_venv" 
       vars:

--- a/docs/module_maintenance_planner_files.md
+++ b/docs/module_maintenance_planner_files.md
@@ -68,7 +68,7 @@ Obtain list of SAP Software files using existing Python Virtual Environment `/tm
         transaction_name: "Transaction Name or Display ID from Maintenance Planner"
       register: __module_results
       environment:
-        PATH: "/tmp/python_venv:{{ ansible_env.PATH }}" 
+        PATH: "/tmp/python_venv:{{ ansible_facts['env'].PATH }}" 
         PYTHONPATH: "/tmp/python_venv/lib/python3.11/site-packages" 
         VIRTUAL_ENV: "/tmp/python_venv" 
       vars:
@@ -138,7 +138,7 @@ Install prerequisites and obtain list of SAP Software files using existing Pytho
         transaction_name: "Transaction Name or Display ID from Maintenance Planner"
       register: __module_results
       environment:
-        PATH: "/tmp/python_venv:{{ ansible_env.PATH }}" 
+        PATH: "/tmp/python_venv:{{ ansible_facts['env'].PATH }}" 
         PYTHONPATH: "/tmp/python_venv/lib/python3.11/site-packages" 
         VIRTUAL_ENV: "/tmp/python_venv" 
       vars:

--- a/docs/module_maintenance_planner_stack_xml_download.md
+++ b/docs/module_maintenance_planner_stack_xml_download.md
@@ -71,7 +71,7 @@ Obtain Stack file using existing Python Virtual Environment `/tmp/venv`.
         dest: "Enter download path (e.g. /software)"
       register: __module_results
       environment:
-        PATH: "/tmp/venv:{{ ansible_env.PATH }}" 
+        PATH: "/tmp/venv:{{ ansiblansible_facts['env']e_env.PATH }}" 
         PYTHONPATH: "/tmp/venv/lib/python3.11/site-packages" 
         VIRTUAL_ENV: "/tmp/venv" 
       vars:
@@ -143,7 +143,7 @@ Install prerequisites and obtain Stack file using existing Python Virtual Enviro
         dest: "Enter download path (e.g. /software)"
       register: __module_results
       environment:
-        PATH: "/tmp/venv:{{ ansible_env.PATH }}" 
+        PATH: "/tmp/venv:{{ ansible_facts['env'].PATH }}" 
         PYTHONPATH: "/tmp/venv/lib/python3.11/site-packages" 
         VIRTUAL_ENV: "/tmp/venv" 
       vars:

--- a/docs/module_software_center_download.md
+++ b/docs/module_software_center_download.md
@@ -125,7 +125,7 @@ Download SAP Software file using Python Virtual Environment `/tmp/venv`
         search_query: "Enter SAP Software file name"
         dest: "Enter download path (e.g. /software)"
       environment:
-        PATH: "/tmp/venv:{{ ansible_env.PATH }}" 
+        PATH: "/tmp/venv:{{ ansible_facts['env'].PATH }}" 
         PYTHONPATH: "/tmp/venv/lib/python3.11/site-packages" 
         VIRTUAL_ENV: "/tmp/venv" 
       vars:
@@ -195,7 +195,7 @@ Install prerequisites and download SAP Software file using existing Python Virtu
         search_query: "Enter SAP Software file name"
         dest: "Enter download path (e.g. /software)"
       environment:
-        PATH: "/tmp/python_venv:{{ ansible_env.PATH }}" 
+        PATH: "/tmp/python_venv:{{ ansible_facts['env'].PATH }}" 
         PYTHONPATH: "/tmp/python_venv/lib/python3.11/site-packages" 
         VIRTUAL_ENV: "/tmp/python_venv" 
       vars:

--- a/roles/sap_software_download/tasks/download_files.yml
+++ b/roles/sap_software_download/tasks/download_files.yml
@@ -16,7 +16,7 @@
     label: "{{ item }} : {{ __sap_software_download_files_results_venv.msg | d('') }}"
   register: __sap_software_download_files_results_venv
   environment:
-    PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_facts['env'].PATH }}"
     PYTHONPATH: "{{ __sap_software_download_venv.path }}/lib/{{ sap_software_download_python_interpreter }}/site-packages"
     VIRTUAL_ENV: "{{ __sap_software_download_venv.path }}"
   vars:

--- a/roles/sap_software_download/tasks/download_plan.yml
+++ b/roles/sap_software_download/tasks/download_plan.yml
@@ -15,7 +15,7 @@
     label: "{{ item.Filename }} : {{ __sap_software_download_files_plan_results_venv.msg | d('') }}"
   register: __sap_software_download_files_plan_results_venv
   environment:
-    PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_facts['env'].PATH }}"
     PYTHONPATH: "{{ __sap_software_download_venv.path }}/lib/{{ sap_software_download_python_interpreter }}/site-packages"
     VIRTUAL_ENV: "{{ __sap_software_download_venv.path }}"
   vars:

--- a/roles/sap_software_download/tasks/download_stack.yml
+++ b/roles/sap_software_download/tasks/download_stack.yml
@@ -10,7 +10,7 @@
     dest: "{{ sap_software_download_directory }}"
   register: __sap_software_download_stack_results_venv
   environment:
-    PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_facts['env'].PATH }}"
     PYTHONPATH: "{{ __sap_software_download_venv.path }}/lib/{{ sap_software_download_python_interpreter }}/site-packages"
     VIRTUAL_ENV: "{{ __sap_software_download_venv.path }}"
   vars:

--- a/roles/sap_software_download/tasks/pre_steps/01_include_variables.yml
+++ b/roles/sap_software_download/tasks/pre_steps/01_include_variables.yml
@@ -12,16 +12,16 @@
   loop: "{{ __var_files }}"
   vars:
     __vars_file: "{{ role_path }}/vars/{{ item }}"
-    __distribution_major: "{{ ansible_distribution ~ '_' ~ ansible_distribution_major_version }}"
-    __distribution_minor: "{{ ansible_distribution ~ '_' ~ ansible_distribution_version }}"
+    __distribution_major: "{{ ansible_facts['distribution'] ~ '_' ~ ansible_facts['distribution_major_version'] }}"
+    __distribution_minor: "{{ ansible_facts['distribution'] ~ '_' ~ ansible_facts['distribution_version'] }}"
     # Enables loading of shared vars between SLES and SLES_SAP
-    __distribution_major_split: "{{ ansible_distribution.split('_')[0] ~ '_' ~ ansible_distribution_major_version }}"
-    __distribution_minor_split: "{{ ansible_distribution.split('_')[0] ~ '_' ~ ansible_distribution_version }}"
+    __distribution_major_split: "{{ ansible_facts['distribution'].split('_')[0] ~ '_' ~ ansible_facts['distribution_major_version'] }}"
+    __distribution_minor_split: "{{ ansible_facts['distribution'].split('_')[0] ~ '_' ~ ansible_facts['distribution_version'] }}"
     __var_files: >-
       {{
         [
-          ansible_os_family ~ '.yml',
-          (ansible_distribution ~ '.yml') if ansible_distribution != ansible_os_family else None,
+          ansible_facts['os_family'] ~ '.yml',
+          (ansible_facts['distribution'] ~ '.yml') if ansible_facts['distribution'] != ansible_facts['os_family'] else None,
           (__distribution_major_split ~ '.yml') if __distribution_major_split != __distribution_major else None,
           (__distribution_minor_split ~ '.yml') if __distribution_minor_split != __distribution_minor else None,
           __distribution_major ~ '.yml',

--- a/roles/sap_software_download/tasks/pre_steps/03_validate_credentials.yml
+++ b/roles/sap_software_download/tasks/pre_steps/03_validate_credentials.yml
@@ -16,7 +16,7 @@
   retries: 1
   delay: 5
   environment:
-    PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_facts['env'].PATH }}"
     PYTHONPATH: "{{ __sap_software_download_venv.path }}/lib/{{ sap_software_download_python_interpreter }}/site-packages"
     VIRTUAL_ENV: "{{ __sap_software_download_venv.path }}"
   vars:

--- a/roles/sap_software_download/tasks/pre_steps/04_get_plan_files.yml
+++ b/roles/sap_software_download/tasks/pre_steps/04_get_plan_files.yml
@@ -10,7 +10,7 @@
   register: __sap_software_download_mp_transaction_results_venv
   retries: 1
   environment:
-    PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_facts['env'].PATH }}"
     PYTHONPATH: "{{ __sap_software_download_venv.path }}/lib/{{ sap_software_download_python_interpreter }}/site-packages"
     VIRTUAL_ENV: "{{ __sap_software_download_venv.path }}"
   vars:

--- a/roles/sap_software_download/tasks/pre_steps/05_validate_relations.yml
+++ b/roles/sap_software_download/tasks/pre_steps/05_validate_relations.yml
@@ -22,7 +22,7 @@
       retries: 1
       until: __sap_software_download_files_results_dryrun_venv is not failed
       environment:
-        PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_env.PATH }}"
+        PATH: "{{ __sap_software_download_venv.path }}/bin:{{ ansible_facts['env'].PATH }}"
         PYTHONPATH: "{{ __sap_software_download_venv.path }}/lib/{{ sap_software_download_python_interpreter }}/site-packages"
         VIRTUAL_ENV: "{{ __sap_software_download_venv.path }}"
       vars:

--- a/roles/sap_software_download/vars/SLES_15.yml
+++ b/roles/sap_software_download/vars/SLES_15.yml
@@ -9,7 +9,7 @@
 # Set which Python version will be used on destination node.
 # This is python executable name, which can differ from python package name.
 __sap_software_download_python_interpreter: >-
-  {%- if ansible_distribution_version.split('.')[1] | int < 5 -%}
+  {%- if ansible_facts['distribution_version'].split('.')[1] | int < 5 -%}
     python3
   {%- else -%}
     python3.11
@@ -17,7 +17,7 @@ __sap_software_download_python_interpreter: >-
 
 # Set which Python package will be installed on destination node.
 __sap_software_download_python_package: >-
-  {%- if ansible_distribution_version.split('.')[1] | int < 5 -%}
+  {%- if ansible_facts['distribution_version'].split('.')[1] | int < 5 -%}
     python3
   {%- else -%}
     python311
@@ -27,7 +27,7 @@ __sap_software_download_python_package: >-
 # This is required in order to avoid externally-managed-environment error.
 __sap_software_download_python_module_packages:
   "{{ __sap_software_download_python_module_packages_3
-    if ansible_distribution_version.split('.')[1] | int < 5
+    if ansible_facts['distribution_version'].split('.')[1] | int < 5
     else __sap_software_download_python_module_packages_311 }}"
 
 # The lists of Python Modules for specific python version


### PR DESCRIPTION
## Changes
Updated all injected vars to `ansible_facts` in order to remove deprecation warning for `ansible-core 2.20`.

Replaced vars:
```
ansible_distribution
ansible_distribution_major_version
ansible_distribution_version
ansible_env
ansible_os_family
```

## Tests
Tested on SLES_SAP 16.0 on premise.