### PR TITLE
software_center_download: Update fuzzy search logic and deduplicate sorting

### DIFF
--- a/docs/module_software_center_download.md
+++ b/docs/module_software_center_download.md
@@ -3,6 +3,7 @@
 ## Description
 The Ansible Module `software_center_download` automates downloading files from the SAP Software Center.
 - It can find a file using a search query or download it directly using a specific download link and filename.
+- Supports wildcard search to find and download specific versions (oldest/newest) from multiple available versions.
 - If a file is not found via search, it can look for alternative versions.
 - It supports checksum validation to ensure file integrity and avoid re-downloading valid files.
 - The module can also perform a dry run to check for file availability without downloading.
@@ -17,6 +18,39 @@ This module requires the following Python modules to be installed on the target 
 - lxml
 
 ## Execution
+
+### Wildcard Search Format
+The module supports wildcard search to find files across multiple versions. This is useful when you want to download the latest (or oldest) version of a software package without knowing the exact version number.
+
+**Format:** `PREFIX*-ID.EXT`
+
+Where:
+
+- `PREFIX`: The software name prefix (e.g., `SAPEXE`, `SAPHOSTAGENT`).
+- `*`: Single wildcard representing the version number.
+- `-`: Dash separator (required).
+- `ID`: File ID number (e.g., `80002630`).
+- `.EXT`: File extension (e.g., `.SAR`, `.EXE`).
+
+> **NOTE:** File ID is unique number that represents combination of component and platform version. 
+
+**Requirements:**
+- The parameter `search_alternatives: true` must be enabled.
+- Only one wildcard (`*`) is allowed per query.
+- File format must include both dash and extension according to pattern above.
+- Use `deduplicate` parameter to select oldest (`first`) or newest (`last`) version.
+
+**Examples:**
+- `SWPM20SP2*-80003424.SAR` - Matches all available SWPM20 versions starting with `2` (SWPM20SP23, SWPM20SP24, etc.) for `Linux on x86_64 64bit` (80003424).
+- `SAPEXE_10*-80002630.SAR` - Matches all available SAPEXE_10 versions starting with `10` (SAPEXE_10, SAPEXE_100, SAPEXE_1000, etc.) for `Linux on Power LE 64bit` (80002630).
+- `SAPHOSTAGENT*-80004822.SAR` - Matches all available SAPHOSTAGENT versions for `Linux on x86_64 64bit` (80004822).
+
+**Special Files:**
+Some SAP media files don't follow the standard naming pattern and require exact filenames:
+
+- `S4CORE107_INST_EXPORT_1.zip`
+- `KD75783.SAR`
+- `19118000000000009032` (SAP Media downloaded with ID instead of Title).
 
 ### Execution Flow
 The module follows a sophisticated logic flow to determine whether to download, skip, or fail. Here is a simplified breakdown of the decision-making process:
@@ -86,6 +120,31 @@ Download SAP Software file using download_link and download_filename
         download_link: 'https://softwaredownloads.sap.com/file/0010000000048502015'
         download_filename: 'IW_FNDGC100.SAR'
         dest: "Enter download path (e.g. /software)"
+```
+
+Download latest version of SAP Software using wildcard search
+```yaml
+---
+- name: Example play for Ansible Module software_center_download
+  hosts: all
+  tasks:
+    - name: Download latest SAPEXE version using wildcard
+      community.sap_launchpad.software_center_download:
+        suser_id: "Enter SAP S-User ID"
+        suser_password: "Enter SAP S-User Password"
+        search_query: "SAPEXE*-80002630.SAR"
+        dest: "Enter download path (e.g. /software)"
+        search_alternatives: true
+        deduplicate: "last"
+    
+    - name: Download oldest SAPHOSTAGENT version using wildcard
+      community.sap_launchpad.software_center_download:
+        suser_id: "Enter SAP S-User ID"
+        suser_password: "Enter SAP S-User Password"
+        search_query: "SAPHOSTAGENT*-80004822.SAR"
+        dest: "Enter download path (e.g. /software)"
+        search_alternatives: true
+        deduplicate: "first"
 ```
 
 Download list of SAP Software files, but search for alternatives if not found
@@ -230,7 +289,15 @@ The password for the SAP S-User specified in `suser_id`.
 ### search_query
 - _Type:_ `string`<br>
 
-The SAP software file name to download.
+The SAP software file name to download.<br>
+Supports wildcard format for version matching when `search_alternatives` is enabled.<br>
+
+**Wildcard Format:** `PREFIX*-ID.EXT`<br>
+- Only one wildcard (`*`) is allowed per query<br>
+- Example: `SAPEXE*-80002630.SAR` matches all SAPEXE versions<br>
+
+**Exact Filename:** Use the complete filename without wildcards for specific files.<br>
+- Example: `SAPCAR_1324-80000936.EXE`
 
 ### download_link
 - _Type:_ `string`<br>
@@ -252,16 +319,29 @@ The directory where downloaded SAP software files will be stored.
 
 ### deduplicate
 - _Type:_ `string`<br>
+- _Choices:_ `first`, `last`, `` (empty)<br>
 
-Specifies how to handle multiple search results for the same filename.<br>
-If multiple files with the same name are found, this setting determines which one to download.<br>
-- `first`: Download the first file found (oldest).<br>
-- `last`: Download the last file found (newest).<br>
+Specifies how to handle multiple search results when using wildcard queries.<br>
+Only applies when `search_alternatives` is enabled and multiple versions are found.<br>
+
+**Options:**<br>
+- `first`: Download the oldest version<br>
+- `last`: Download the newest version<br>
+- `` (empty): If multiple results are found, display all available versions and fail with an error<br>
+
+Files are sorted numerically by version number, ensuring correct ordering (e.g., version 7 < 10 < 100 < 1500).<br>
 
 ### search_alternatives
 - _Type:_ `boolean`<br>
+- _Default:_ `false`<br>
 
 Enables searching for alternative files if the requested file is not found.<br>
+**Required** when using wildcard queries in `search_query`.<br>
+
+**Requirements:**<br>
+- Only works for files following the format `PREFIX-ID.EXT` (with dash and extension)<br>
+- Special media files without this pattern (e.g., `S4CORE107_INST_EXPORT_1.zip`) must use exact filenames<br>
+- Wildcard searches are not supported for files without dashes or extensions<br>
 
 ### dry_run
 - _Type:_ `boolean

--- a/docs/module_software_center_download.md
+++ b/docs/module_software_center_download.md
@@ -320,6 +320,7 @@ The directory where downloaded SAP software files will be stored.
 ### deduplicate
 - _Type:_ `string`<br>
 - _Choices:_ `first`, `last`, `` (empty)<br>
+- _Default:_ `last`<br>
 
 Specifies how to handle multiple search results.<br>
 Only applies when `search_alternatives` is enabled and multiple versions are found.<br>

--- a/docs/module_software_center_download.md
+++ b/docs/module_software_center_download.md
@@ -188,7 +188,7 @@ Download SAP Software file using Python Virtual Environment `/tmp/venv`
         PYTHONPATH: "/tmp/venv/lib/python3.11/site-packages" 
         VIRTUAL_ENV: "/tmp/venv" 
       vars:
-        ansible_python_interpreter: "/tmp/venv/bin/python3.11 }}"
+        ansible_python_interpreter: "/tmp/venv/bin/python3.11"
 ```
 
 Install prerequisites and download SAP Software file using existing System Python.</br>
@@ -258,7 +258,7 @@ Install prerequisites and download SAP Software file using existing Python Virtu
         PYTHONPATH: "/tmp/python_venv/lib/python3.11/site-packages" 
         VIRTUAL_ENV: "/tmp/python_venv" 
       vars:
-        ansible_python_interpreter: "/tmp/python_venv/bin/python3.11 }}"
+        ansible_python_interpreter: "/tmp/python_venv/bin/python3.11"
 ```
 
 ### Output format
@@ -321,7 +321,7 @@ The directory where downloaded SAP software files will be stored.
 - _Type:_ `string`<br>
 - _Choices:_ `first`, `last`, `` (empty)<br>
 
-Specifies how to handle multiple search results when using wildcard queries.<br>
+Specifies how to handle multiple search results.<br>
 Only applies when `search_alternatives` is enabled and multiple versions are found.<br>
 
 **Options:**<br>

--- a/plugins/module_utils/software_center/search.py
+++ b/plugins/module_utils/software_center/search.py
@@ -124,11 +124,6 @@ def find_file(client, name, deduplicate, search_alternatives):
             if file.get('Title', '').upper().endswith(file_extension.upper())
         ]
 
-        # Sort numerically: 'first' = oldest, 'last' = newest
-        software_search_alternatives_filtered = _sort_fuzzy_results(
-            software_search_alternatives_filtered
-        )
-
         alternatives_count = len(software_search_alternatives_filtered)
         if alternatives_count == 0:
             raise FileNotFoundError(f'File "{name}" is not available and no alternatives could be found.')
@@ -377,7 +372,7 @@ def _sort_fuzzy_results(fuzzy_results_filtered):
         software_fuzzy_sorted = sorted(
             fuzzy_results_filtered,
             key=lambda item: (
-                _get_numeric_search_keyword(item.get('Title', '')) or 0
+                _get_numeric_search_keyword(item.get('Title', '')) or (0, 0)
             ),
             reverse=False,
         )
@@ -391,12 +386,29 @@ def _sort_fuzzy_results(fuzzy_results_filtered):
 
 
 def _get_numeric_search_keyword(filename):
-    # Extracts integer value of version from filename.
+    # Extracts version tuple from filename for sorting.
+    # Returns tuple (major, minor) to handle cases like SP24_0, SP24_1, SP24_10.
+    # Priority: extract the most significant version numbers.
+
+    # For SP-based files: extract (SP_version, patch_number)
+    # SWPM20SP23_4-ID -> (23, 4), SWPM20SP24_1-ID -> (24, 1)
+    sp_match = re.search(r'SP(\d+)_(\d+)-', filename)
+    if sp_match:
+        return (int(sp_match.group(1)), int(sp_match.group(2)))
+
+    # For HANA files with 3-part versions: extract (revision, patch)
+    # IMDB_SERVER20_067_4-ID -> (67, 4), IMDB_LCAPPS_2067P_400-ID -> (2067, 400)
+    hana_match = re.search(r'_(\d+)P?_(\d+)-', filename)
+    if hana_match:
+        return (int(hana_match.group(1)), int(hana_match.group(2)))
+
+    # For all other files: extract version as (version, 0) for consistent tuple sorting
+    # SAPEXE_800-ID -> (800, 0), SAPHOSTAGENT61_61-ID -> (61, 0), igsexe_13-ID -> (13, 0)
     match = re.search(r'_(\d+)-', filename)
     if match:
-        return int(match.group(1))
-    else:
-        return None
+        return (int(match.group(1)), 0)
+
+    return None
 
 
 def _remove_useless_keys(result):

--- a/plugins/module_utils/software_center/search.py
+++ b/plugins/module_utils/software_center/search.py
@@ -28,13 +28,6 @@ def find_file(client, name, deduplicate, search_alternatives):
         has_extension = '.' in name
         has_dash = '-' in name
 
-        # More than one wildcards are not allowed.
-        if wildcard_count > 1:
-            raise FileNotFoundError(
-                f'File "{name}" is not available.\n'
-                f'Only one wildcard (*) is allowed in the search query.'
-            )
-
         # No wildcards were detected.
         if wildcard_count == 0:
             # File format doesn't support fuzzy search.
@@ -61,7 +54,7 @@ def find_file(client, name, deduplicate, search_alternatives):
                 f'Wildcard search requires search_alternatives to be enabled.'
             )
 
-        # One wildcard was detected, validate wildcard position and format.
+        # Wildcard detected, validate format with regex.
         if wildcard_count > 0:
             # We have to ensure that only correct pattern is accepted: PREFIX*-ID.EXT
             # Having wildcard in other places would result in API timeouts
@@ -113,8 +106,8 @@ def find_file(client, name, deduplicate, search_alternatives):
             )
 
         # Fuzzy search already filtered by prefix and ID.
-        # Now filter by extension to handle different file types (.SAR vs .rpm)
-        # Extract extension from original query
+        # Filter by extension to handle different file types (.SAR vs .rpm)
+        # Results are already sorted from _filter_fuzzy_search
         file_right_side = name.split('-')[-1]  # 80004822.SAR
         file_id = file_right_side.split('.')[0]  # 80004822
         file_extension = file_right_side[len(file_id):]  # .SAR

--- a/plugins/module_utils/software_center/search.py
+++ b/plugins/module_utils/software_center/search.py
@@ -28,6 +28,13 @@ def find_file(client, name, deduplicate, search_alternatives):
         has_extension = '.' in name
         has_dash = '-' in name
 
+        # Multiple wildcards cause split() to fail in _filter_fuzzy_search.
+        if wildcard_count > 1:
+            raise FileNotFoundError(
+                f'File "{name}" is not available.\n'
+                f'Only one wildcard (*) is allowed in the search query.'
+            )
+
         # No wildcards were detected.
         if wildcard_count == 0:
             # File format doesn't support fuzzy search.

--- a/plugins/module_utils/software_center/search.py
+++ b/plugins/module_utils/software_center/search.py
@@ -22,32 +22,113 @@ def find_file(client, name, deduplicate, search_alternatives):
 
     files_count = len(software_filtered)
     if files_count == 0:
-        # If no exact match is found, and alternatives are requested, perform a fuzzy search.
-        if not search_alternatives:
-            raise FileNotFoundError(f'File "{name}" is not available. To find a replacement, enable "search_alternatives".')
+        # Gather facts about filename for decision making.
+        # Check if file format supports alternative search (has dash and extension).
+        wildcard_count = name.count('*')
+        has_extension = '.' in name
+        has_dash = '-' in name
 
-        software_fuzzy_found = _search_software_fuzzy(client, name)
+        # More than one wildcards are not allowed.
+        if wildcard_count > 1:
+            raise FileNotFoundError(
+                f'File "{name}" is not available.\n'
+                f'Only one wildcard (*) is allowed in the search query.'
+            )
+
+        # No wildcards were detected.
+        if wildcard_count == 0:
+            # File format doesn't support fuzzy search.
+            # No reason to offer search_alternatives or wildcard suggestions.
+            if not (has_dash and has_extension):
+                raise FileNotFoundError(
+                    f'File "{name}" is not available.'
+                )
+
+            # File format supports fuzzy, suggest search_alternatives if disabled.
+            if not search_alternatives:
+                raise FileNotFoundError(
+                    f'File "{name}" is not available.\n'
+                    f'To search for different versions, '
+                    f'enable "search_alternatives" and use wildcard format.\n'
+                    f'Format: "PREFIX*-ID.EXT"\n'
+                    f'Example: "SAPEXE_1*-80002630.SAR"'
+                )
+
+        # Wildcard detected, but search_alternatives is disabled.
+        if not search_alternatives:
+            raise FileNotFoundError(
+                f'File "{name}" is not available.\n'
+                f'Wildcard search requires search_alternatives to be enabled.'
+            )
+
+        # search_alternatives is enabled - validate format for fuzzy search.
+        if not (has_dash and has_extension):
+            raise FileNotFoundError(
+                f'File "{name}" is not available.\n'
+                f'Wildcard queries must follow specific format.\n'
+                f'Format: "PREFIX*-ID.EXT"\n'
+                f'Example: "SAPEXE_1*-80002630.SAR"'
+            )
+
+        try:
+            software_fuzzy_found = _search_software_fuzzy(client, name)
+        except Exception as e:
+            # Handle cases where API returns errors due to overly broad queries
+            if 'RetryError' in str(type(e).__name__) or '500 error' in str(e):
+                if wildcard_count > 0:
+                    raise FileNotFoundError(
+                        f'File "{name}" is not available.\n'
+                        f'The search query may be too broad, or SAP API is experiencing issues.\n'
+                        f'Options:\n'
+                        f' - Use a more specific wildcard pattern\n'
+                        f'   Example: Instead of "SAPEXE_9*-80002630.SAR", use "SAPEXE_900*-80002630.SAR"\n'
+                        f' - Wait and retry later when SAP API is available again'
+                    )
+            # Re-raise other exceptions
+            raise
+
         software_fuzzy_filtered, suggested_filename = _filter_fuzzy_search(software_fuzzy_found, name)
         if len(software_fuzzy_filtered) == 0:
-            raise FileNotFoundError(f'File "{name}" is not available and no alternatives could be found.')
+            raise FileNotFoundError(
+                f'File "{name}" is not available '
+                f'and no alternatives could be found.'
+            )
 
-        software_fuzzy_alternatives = software_fuzzy_filtered[0].get('Title')
+        # Fuzzy search already filtered by prefix and ID.
+        # Now filter by extension to handle different file types (.SAR vs .rpm)
+        # Extract extension from original query
+        file_right_side = name.split('-')[-1]  # 80004822.SAR
+        file_id = file_right_side.split('.')[0]  # 80004822
+        file_extension = file_right_side[len(file_id):]  # .SAR
 
-        # The fuzzy search can return duplicates (e.g., .sar and .SAR).
-        # We must perform another direct search on the best alternative and filter it.
-        # duplicates like 70SWPM10SP43_2-20009701.sar for SWPM10SP43_2-20009701.SAR
-        software_search_alternatives = _search_software(client, software_fuzzy_alternatives)
         software_search_alternatives_filtered = [
-            file for file in software_search_alternatives
-            if file.get('Title', '').startswith(suggested_filename)
+            file for file in software_fuzzy_filtered
+            if file.get('Title', '').upper().endswith(file_extension.upper())
         ]
+
+        # Sort numerically: 'first' = oldest, 'last' = newest
+        software_search_alternatives_filtered = _sort_fuzzy_results(
+            software_search_alternatives_filtered
+        )
 
         alternatives_count = len(software_search_alternatives_filtered)
         if alternatives_count == 0:
             raise FileNotFoundError(f'File "{name}" is not available and no alternatives could be found.')
         elif alternatives_count > 1 and deduplicate == '':
             names = [s['Title'] for s in software_search_alternatives_filtered]
-            raise FileNotFoundError(f'More than one alternative was found: {", ".join(names)}. Please use a more specific filename.')
+
+            first_option = software_search_alternatives_filtered[0]['Title']
+            last_option = software_search_alternatives_filtered[-1]['Title']
+
+            raise FileNotFoundError(
+                f'More than one alternative was found: '
+                f'{", ".join(names)}.\n'
+                f'Please use a more specific filename '
+                f'or set deduplicate parameter.\n'
+                f'Options for deduplicate:\n'
+                f' - "first" returns oldest version ({first_option})\n'
+                f' - "last" returns newest version ({last_option})'
+            )
         elif alternatives_count > 1 and deduplicate == 'first':
             software_found = software_search_alternatives_filtered[0]
             alternative_found = True
@@ -59,10 +140,23 @@ def find_file(client, name, deduplicate, search_alternatives):
             software_found = software_search_alternatives_filtered[0]
             alternative_found = True
 
+    # There should never be case when exact file is found with more than one match,
+    # but handle it just in case.
     elif files_count > 1 and deduplicate == '':
         # Handle cases where the direct search returns multiple exact matches.
         names = [s['Title'] for s in software_filtered]
-        raise FileNotFoundError(f'More than one result was found: {", ".join(names)}. Please use the correct full filename.')
+
+        first_option = software_filtered[0]['Title']
+        last_option = software_filtered[-1]['Title']
+
+        raise FileNotFoundError(
+            f'More than one result was found: {", ".join(names)}.\n'
+            f'Please use the correct full filename '
+            f'or set deduplicate parameter.\n'
+            f'Options for deduplicate:\n'
+            f' - "first" returns oldest version ({first_option})\n'
+            f' - "last" returns newest version ({last_option})'
+        )
     elif files_count > 1 and deduplicate == 'first':
         software_found = software_filtered[0]
     elif files_count > 1 and deduplicate == 'last':
@@ -101,35 +195,60 @@ def _search_software(client, keyword):
 
 
 def _search_software_fuzzy(client, query):
-    # Executes a fuzzy search using the unique software ID from the filename.
+    # Executes a fuzzy search to find alternative versions.
+    # Strategy: Try prefix search first (more specific), fallback to ID search if needed.
     filename_base = os.path.splitext(query)[0]
 
     # This excludes unique files without ID like: S4CORE105_INST_EXPORT_1.zip
     if '-' not in filename_base:
         return []
 
+    # Extract ID and prepare suggested filename prefix
     filename_id = filename_base.split('-')[-1]
-    results = _search_software(client, filename_id)
-    num = 0
+    suggested_filename, suggested_filename_next = _prepare_search_filename(query)
+    has_wildcard = '*' in query
 
     fuzzy_results = []
-    while True:
+
+    # For exact filenames, try prefix search first (more targeted, avoids API limits)
+    if not has_wildcard:
+        # Search by suggested prefix
+        results = _search_software(client, suggested_filename)
+
+        # Filter results by ID to ensure correct platform
         for r in results:
-            r = _remove_useless_keys(r)
-            fuzzy_results.append(r)
-        num += len(results)
+            if f'-{filename_id}' in r.get('Title', ''):
+                fuzzy_results.append(_remove_useless_keys(r))
 
-        if not results:
-            break
+        # If empty and suggested_filename_next exists, try incremented version
+        if len(fuzzy_results) == 0 and suggested_filename_next:
+            results = _search_software(client, suggested_filename_next)
+            for r in results:
+                if f'-{filename_id}' in r.get('Title', ''):
+                    fuzzy_results.append(_remove_useless_keys(r))
 
-        query_string = _get_next_page_query(results[-1]['SearchResultDescr'])
-        if not query_string:
-            break
+    # For wildcards or if prefix search found nothing, use ID-based search
+    if has_wildcard or len(fuzzy_results) == 0:
+        results = _search_software(client, filename_id)
+        num = 0
 
-        url = C.URL_SOFTWARE_CENTER_SERVICE + '/SearchResultSet'
-        query_url = '?'.join((url, query_string))
-        headers = {'User-Agent': C.USER_AGENT_CHROME, 'Accept': 'application/json'}
-        results = client.get(query_url, headers=headers, allow_redirects=False).json().get('d', {}).get('results', [])
+        while True:
+            for r in results:
+                r = _remove_useless_keys(r)
+                fuzzy_results.append(r)
+            num += len(results)
+
+            if not results:
+                break
+
+            query_string = _get_next_page_query(results[-1]['SearchResultDescr'])
+            if not query_string:
+                break
+
+            url = C.URL_SOFTWARE_CENTER_SERVICE + '/SearchResultSet'
+            query_url = '?'.join((url, query_string))
+            headers = {'User-Agent': C.USER_AGENT_CHROME, 'Accept': 'application/json'}
+            results = client.get(query_url, headers=headers, allow_redirects=False).json().get('d', {}).get('results', [])
 
     return fuzzy_results
 
@@ -145,132 +264,111 @@ def _filter_fuzzy_search(fuzzy_results, filename):
         ]
         suggested_filename = prefix
     else:
-        suggested_filename = _prepare_search_filename_specific(filename)
+        suggested_filename, suggested_filename_next = _prepare_search_filename(filename)
+
+        # Create result list with same version if available.
         fuzzy_results_filtered = [
             file for file in fuzzy_results
             if file.get('Title', '').startswith(suggested_filename)
         ]
 
-        if len(fuzzy_results_filtered) == 0:
-            suggested_filename = _prepare_search_filename_nonspecific(filename)
+        # Attempt to create result list with incremented version.
+        if len(fuzzy_results_filtered) == 0 and suggested_filename_next:
             fuzzy_results_filtered = [
                 file for file in fuzzy_results
-                if file.get('Title', '').startswith(suggested_filename)
+                if file.get('Title', '').startswith(suggested_filename_next)
             ]
+            # Update return suggested filename to incremented version if alternatives are found with it.
+            if len(fuzzy_results_filtered) > 0:
+                suggested_filename = suggested_filename_next
 
-    fuzzy_results_sorted = _sort_fuzzy_results(fuzzy_results_filtered, filename)
+    fuzzy_results_sorted = _sort_fuzzy_results(fuzzy_results_filtered)
     return fuzzy_results_sorted, suggested_filename
 
 
-def _prepare_search_filename_specific(filename):
+def _prepare_search_filename(filename):
     # Prepares a suggested search keyword for known products specific to SPS version.
+    # Filename without extension.
     filename_base = os.path.splitext(filename)[0]
-    filename_name = filename_base.rsplit('_', 1)[0]
 
+    # Filename before first '-' character.
+    filename_main = filename_base.split('-')[0]
+
+    # Filename split into individual components: ['IMDB', 'AFL100', '102P', '41']
+    filename_parts = filename_main.split('_')
+
+    # Example: SWPM20SP23_4-70003174.SAR returns SWPM20SP23
     for swpm_version in ("70SWPM1", "70SWPM2", "SWPM1", "SWPM2"):
         if filename_base.startswith(swpm_version):
-            return swpm_version
+            suggested = filename_parts[0]
+            return suggested, _increment_last_digits(suggested)
 
     # Example: SUM11SP04_2-80006858.SAR returns SUM11SP04
-    if filename_base.startswith('SUM'):
-        return filename.split('-')[0].split('_')[0]
-
     # Example: DBATL740O11_48-80002605.SAR returns DBATL740O11
-    elif filename_base.startswith('DBATL'):
-        return filename.split('-')[0].split('_')[0]
+    if filename_base.startswith(('SUM', 'DBATL')):
+        suggested = filename_parts[0]
+        return suggested, _increment_last_digits(suggested)
 
-    # Example: IMDB_AFL20_077_0-80002045.SAR returns IMDB_AFL20_077
-    # Example: IMDB_AFL100_102P_41-10012328.SAR returns MDB_AFL100_102P
-    elif filename_base.startswith('IMDB_AFL'):
-        return "_".join(filename.split('-')[0].split('_')[:3])
+
+    # Revision version will be kept to ensure correct component versions.
+    # Example: IMDB_SERVER20_067_4-80002046.SAR returns IMDB_SERVER20_067 (Rev 67)
+    # Example: IMDB_AFL20_077_0-80002045.SAR returns IMDB_AFL20_077 (Rev 77)
+    # Example: IMDB_AFL100_102P_41-10012328.SAR returns MDB_AFL100_102 (Rev 102)
+    # Example: IMDB_LCAPPS_122P_3300-20010426.SAR returns IMDB_LCAPPS_122 (Rev 122)
+    # Example: IMDB_LCAPPS_2067P_400-80002183.SAR returns IMDB_LCAPPS_2067 (Rev 67)
+    elif filename_base.startswith(('IMDB_SERVER', 'IMDB_AFL', 'IMDB_LCAPPS_1', 'IMDB_LCAPPS_2')):       
+        # Remove P from the 3rd element (index 2) to improve fuzzy search.
+        if len(filename_parts) > 2:
+            filename_parts[2] = filename_parts[2].rstrip('Pp') 
+        # Re-join the first three elements -> "IMDB_AFL100_102"
+        suggested = "_".join(filename_parts[:3])
+        return suggested, None
 
     # Example: IMDB_CLIENT20_021_31-80002082.SAR returns IMDB_CLIENT20_021
-    elif filename_base.startswith('IMDB_CLIENT'):
-        return "_".join(filename.split('-')[0].split('_')[:3])
-
-    # Example: IMDB_LCAPPS_122P_3300-20010426.SAR returns IMDB_LCAPPS_122
-    elif filename_base.startswith('IMDB_LCAPPS_1'):
-        filename_parts = filename.split('-')[0].rsplit('_', 2)
-        return f"{filename_parts[0]}_{filename_parts[1][:3]}"
-
-    # Example: IMDB_LCAPPS_2067P_400-80002183.SAR returns IMDB_LCAPPS_206
-    elif filename_base.startswith('IMDB_LCAPPS_2'):
-        filename_parts = filename.split('-')[0].rsplit('_', 2)
-        return f"{filename_parts[0]}_{filename_parts[1][:3]}"
-
-    # Example: IMDB_SERVER20_067_4-80002046.SAR returns IMDB_SERVER20_06 (SPS06)
-    elif filename_base.startswith('IMDB_SERVER'):
-        filename_parts = filename.split('-')[0].rsplit('_', 2)
-        return f"{filename_parts[0]}_{filename_parts[1][:2]}"
+    elif filename_base.startswith('IMDB_CLIENT'):       
+        if len(filename_parts) > 2:
+            filename_parts[2] = filename_parts[2].rstrip('Pp') 
+        suggested = "_".join(filename_parts[:3])
+        return suggested, _increment_last_digits(suggested)
 
     # Example: SAPEXE_100-80005374.SAR returns SAPEXE_100
     elif filename_base.startswith('SAPEXE'):
-        return filename_base.split('-')[0]
+        suggested = filename_main
+        return suggested, _increment_last_digits(suggested)
 
     # Example: SAPHANACOCKPIT02_0-70002300.SAR returns SAPHANACOCKPIT02 (SPS02)
-    elif filename_base.startswith('SAPHANACOCKPIT'):
-        return filename_base.split('-')[0].rsplit('_', 1)[0]
+    # Example: SAPHOSTAGENT61_61-80004831.SAR returns SAPHOSTAGENT61
+    elif filename_base.startswith(('SAPHANACOCKPIT', 'SAPHOSTAGENT')):
+        suggested = filename_main.rsplit('_', 1)[0]
+        return suggested, _increment_last_digits(suggested)
+
     else:
-        return filename_name
+        return filename_main, None
 
 
-def _prepare_search_filename_nonspecific(filename):
-    # Prepares a suggested search keyword for known products non-specific to SPS version.
-    filename_base = os.path.splitext(filename)[0]
-    filename_name = filename_base.rsplit('_', 1)[0]
-
-    # Example: SUM11SP04_2-80006858.SAR returns SUM11
-    if filename_base.startswith('SUM'):
-        if filename_base.startswith('SUMHANA'):
-            return 'SUMHANA'
-        elif filename_base[3:5].isdigit():
-            return filename_base[:5]
-
-    # Example: DBATL740O11_48-80002605.SAR returns DBATL740O11
-    elif filename_base.startswith('DBATL'):
-        return filename.split('-')[0].split('_')[0]
-
-    # Example: IMDB_AFL20_077_0-80002045.SAR returns IMDB_AFL20
-    # Example: IMDB_AFL100_102P_41-10012328.SAR returns IMDB_AFL100
-    elif filename_base.startswith('IMDB_AFL'):
-        return "_".join(filename.split('-')[0].split('_')[:2])
-
-    # Example: IMDB_CLIENT20_021_31-80002082.SAR returns IMDB_CLIENT
-    elif filename_base.startswith('IMDB_CLIENT'):
-        return 'IMDB_CLIENT'
-
-    # Example: IMDB_LCAPPS_122P_3300-20010426.SAR returns IMDB_LCAPPS
-    elif filename_base.startswith('IMDB_LCAPPS'):
-        return "_".join(filename.split('-')[0].split('_')[:2])
-
-    # Example: IMDB_SERVER20_067_4-80002046.SAR returns IMDB_SERVER20
-    elif filename_base.startswith('IMDB_SERVER'):
-        return "_".join(filename.split('-')[0].split('_')[:2])
-
-    # Example: SAPHANACOCKPIT02_0-70002300.SAR returns SAPHANACOCKPIT
-    elif filename_base.startswith('SAPHANACOCKPIT'):
-        return 'SAPHANACOCKPIT'
-
-    # Example: SAPHOSTAGENT61_61-80004831.SAR returns SAPHOSTAGENT
-    elif filename_base.startswith('SAPHOSTAGENT'):
-        return 'SAPHOSTAGENT'
-
-    return filename
-
-
-def _sort_fuzzy_results(fuzzy_results_filtered, filename):
-    # Sorts results of fuzzy search for known nonstandard versions.
-    if _get_numeric_search_keyword(filename):
+def _sort_fuzzy_results(fuzzy_results_filtered):
+    # Numerical sorts for fuzzy search results.
+    # Check if results contain numeric versions.
+    # Ascending: first=oldest, last=newest
+    has_numeric = (
+        fuzzy_results_filtered and
+        _get_numeric_search_keyword(
+            fuzzy_results_filtered[0].get('Title', '')
+        ) is not None
+    )
+    if has_numeric:
         software_fuzzy_sorted = sorted(
             fuzzy_results_filtered,
-            key=lambda item: _get_numeric_search_keyword(item.get('Title', '')),
-            reverse=True,
+            key=lambda item: (
+                _get_numeric_search_keyword(item.get('Title', '')) or 0
+            ),
+            reverse=False,
         )
     else:
         software_fuzzy_sorted = sorted(
             fuzzy_results_filtered,
             key=lambda item: item.get('Title', ''),
-            reverse=True,
+            reverse=False,
         )
     return software_fuzzy_sorted
 
@@ -288,7 +386,7 @@ def _remove_useless_keys(result):
     # Filters a result dictionary to keep only essential keys.
     keys = [
         'Title', 'Description', 'Infotype', 'Fastkey', 'DownloadDirectLink',
-        'ContentInfoLink'
+        'ContentInfoLink', 'SearchResultDescr'
     ]
     return {k: result[k] for k in keys}
 
@@ -312,3 +410,37 @@ def _get_valid_filename(software_found):
             return software_found['Title']
     else:
         return software_found['Title']
+
+
+def _increment_last_digits(suggested_filename):
+    """
+    Increments the trailing digits of a clean, known filename search term.
+    Assumes the string always ends with a numeric character.
+    """
+    if not suggested_filename:
+        return None
+
+    # If the last 2 characters are both digits (e.g., "06", "22", "99")
+    if len(suggested_filename) >= 2 and suggested_filename[-2:].isdigit():
+        last_digits = suggested_filename[-2:]
+
+        # We cannot increase 99 since we focus on 2 digits only.
+        if last_digits == '99':
+            return None
+
+        # int() strips zero so zfill creates two 2 digit again.
+        new_digits = str(int(last_digits) + 1).zfill(2)
+        return suggested_filename[:-2] + new_digits
+
+    # If only the very last character is a digit (e.g., "SPS4", "FILE_1")
+    elif suggested_filename[-1].isdigit():
+        last_digit = suggested_filename[-1]
+
+        # We cannot increase 9 if we do not have 2 last digits.
+        if last_digit == '9':
+            return None
+
+        new_digit = str(int(last_digit) + 1)
+        return suggested_filename[:-1] + new_digit
+
+    return None

--- a/plugins/module_utils/software_center/search.py
+++ b/plugins/module_utils/software_center/search.py
@@ -218,7 +218,7 @@ def _search_software_fuzzy(client, query):
 
     # Extract ID and prepare suggested filename prefix
     filename_id = filename_base.split('-')[-1]
-    suggested_filename, suggested_filename_next = _prepare_search_filename(query)
+    suggested_filename, suggested_filename_next, _ = _prepare_search_filename(query)
     has_wildcard = '*' in query
 
     fuzzy_results = []
@@ -277,7 +277,7 @@ def _filter_fuzzy_search(fuzzy_results, filename):
         ]
         suggested_filename = prefix
     else:
-        suggested_filename, suggested_filename_next = _prepare_search_filename(filename)
+        suggested_filename, suggested_filename_next, suggested_filename_base = _prepare_search_filename(filename)
 
         # Create result list with same version if available.
         fuzzy_results_filtered = [
@@ -295,12 +295,27 @@ def _filter_fuzzy_search(fuzzy_results, filename):
             if len(fuzzy_results_filtered) > 0:
                 suggested_filename = suggested_filename_next
 
+        # Attempt to create result list with broader base prefix.
+        if len(fuzzy_results_filtered) == 0 and suggested_filename_base:
+            fuzzy_results_filtered = [
+                file for file in fuzzy_results
+                if file.get('Title', '').startswith(suggested_filename_base)
+            ]
+            # Update return suggested filename to base if alternatives are found with it.
+            if len(fuzzy_results_filtered) > 0:
+                suggested_filename = suggested_filename_base
+
     fuzzy_results_sorted = _sort_fuzzy_results(fuzzy_results_filtered)
     return fuzzy_results_sorted, suggested_filename
 
 
 def _prepare_search_filename(filename):
-    # Prepares a suggested search keyword for known products specific to SPS version.
+    # Prepares suggested search keywords for known products.
+    # Returns triplet: (suggested, suggested_next, suggested_base)
+    # - suggested: exact version match
+    # - suggested_next: incremented version (safe)
+    # - suggested_base: broader prefix (only for known safe files)
+
     # Filename without extension.
     filename_base = os.path.splitext(filename)[0]
 
@@ -310,52 +325,70 @@ def _prepare_search_filename(filename):
     # Filename split into individual components: ['IMDB', 'AFL100', '102P', '41']
     filename_parts = filename_main.split('_')
 
-    # Example: SWPM20SP23_4-70003174.SAR returns SWPM20SP23
+    # Example: SWPM20SP23_4-70003174.SAR returns (SWPM20SP23, SWPM20SP24, SWPM20)
+    # Example: 70SWPM10SP05_1-20009701.SAR returns (70SWPM10SP05, 70SWPM10SP06, 70SWPM1)
     for swpm_version in ("70SWPM1", "70SWPM2", "SWPM1", "SWPM2"):
         if filename_base.startswith(swpm_version):
             suggested = filename_parts[0]
-            return suggested, _increment_last_digits(suggested)
+            return suggested, _increment_last_digits(suggested), swpm_version
 
-    # Example: SUM11SP04_2-80006858.SAR returns SUM11SP04
-    # Example: DBATL740O11_48-80002605.SAR returns DBATL740O11
-    if filename_base.startswith(('SUM', 'DBATL')):
+    # Example: SUM11SP04_2-80006858.SAR returns (SUM11SP04, SUM11SP05, SUM1)
+    if filename_base.startswith('SUM'):
         suggested = filename_parts[0]
-        return suggested, _increment_last_digits(suggested)
+        # Base is SUM1 or SUM2 (first 4 chars)
+        suggested_base = filename_base[:4] if filename_base[:4] in ('SUM1', 'SUM2') else None
+        return suggested, _increment_last_digits(suggested), suggested_base
+
+    # Example: DBATL740O11_48-80002605.SAR returns (DBATL740O11, DBATL740O12, None)
+    if filename_base.startswith('DBATL'):
+        suggested = filename_parts[0]
+        return suggested, _increment_last_digits(suggested), None
 
     # Revision version will be kept to ensure correct component versions.
-    # Example: IMDB_SERVER20_067_4-80002046.SAR returns IMDB_SERVER20_067 (Rev 67)
-    # Example: IMDB_AFL20_077_0-80002045.SAR returns IMDB_AFL20_077 (Rev 77)
-    # Example: IMDB_AFL100_102P_41-10012328.SAR returns MDB_AFL100_102 (Rev 102)
-    # Example: IMDB_LCAPPS_122P_3300-20010426.SAR returns IMDB_LCAPPS_122 (Rev 122)
-    # Example: IMDB_LCAPPS_2067P_400-80002183.SAR returns IMDB_LCAPPS_2067 (Rev 67)
+    # Example: IMDB_SERVER20_067_4-80002046.SAR (Rev 67) returns (IMDB_SERVER20_067, None, None)
+    # Example: IMDB_AFL20_077_0-80002045.SAR (Rev 77) returns (IMDB_AFL20_077, None, None)
+    # Example: IMDB_AFL100_102P_41-10012328.SAR (Rev 102) returns (IMDB_AFL100_102, None, None)
+    # Example: IMDB_LCAPPS_122P_3300-20010426.SAR (Rev 122) returns (IMDB_LCAPPS_122, None, None)
+    # Example: IMDB_LCAPPS_2067P_400-80002183.SAR (Rev 67) returns (IMDB_LCAPPS_2067, None, None)
     elif filename_base.startswith(('IMDB_SERVER', 'IMDB_AFL', 'IMDB_LCAPPS_1', 'IMDB_LCAPPS_2')):
         # Remove P from the 3rd element (index 2) to improve fuzzy search.
         if len(filename_parts) > 2:
             filename_parts[2] = filename_parts[2].rstrip('Pp')
         # Re-join the first three elements -> "IMDB_AFL100_102"
         suggested = "_".join(filename_parts[:3])
-        return suggested, None
+        return suggested, None, None
 
-    # Example: IMDB_CLIENT20_021_31-80002082.SAR returns IMDB_CLIENT20_021
+    # Example: IMDB_CLIENT20_021_31-80002082.SAR returns (IMDB_CLIENT20_021, IMDB_CLIENT20_022, None)
     elif filename_base.startswith('IMDB_CLIENT'):
         if len(filename_parts) > 2:
             filename_parts[2] = filename_parts[2].rstrip('Pp')
         suggested = "_".join(filename_parts[:3])
-        return suggested, _increment_last_digits(suggested)
+        return suggested, _increment_last_digits(suggested), None
 
-    # Example: SAPEXE_100-80005374.SAR returns SAPEXE_100
+    # Example: SAPEXE_100-80005374.SAR returns (SAPEXE_100, SAPEXE_101, None)
     elif filename_base.startswith('SAPEXE'):
         suggested = filename_main
-        return suggested, _increment_last_digits(suggested)
+        return suggested, _increment_last_digits(suggested), None
 
-    # Example: SAPHANACOCKPIT02_0-70002300.SAR returns SAPHANACOCKPIT02 (SPS02)
-    # Example: SAPHOSTAGENT61_61-80004831.SAR returns SAPHOSTAGENT61
+    # Example: SAPHANACOCKPIT02_0-70002300.SAR returns (SAPHANACOCKPIT02, SAPHANACOCKPIT03, None)
+    # Example: SAPHOSTAGENT61_61-80004831.SAR returns (SAPHOSTAGENT61, SAPHOSTAGENT62, None)
     elif filename_base.startswith(('SAPHANACOCKPIT', 'SAPHOSTAGENT')):
         suggested = filename_main.rsplit('_', 1)[0]
-        return suggested, _increment_last_digits(suggested)
+        return suggested, _increment_last_digits(suggested), None
+
+    # Example: SAPCAR_1100-70007726.EXE returns (SAPCAR_1100, SAPCAR_1200, SAPCAR_)
+    elif filename_base.startswith('SAPCAR_'):
+        suggested = filename_main
+        return suggested, _increment_last_digits(suggested), 'SAPCAR_'
+
+    # Example: igsexe_13-80003187.sar returns (igsexe_13, igsexe_14, None)
+    # Example: igshelper_17-10010245.sar returns (igshelper_17, igshelper_18, None)
+    elif filename_base.startswith(('igsexe_', 'igshelper_')):
+        suggested = filename_main
+        return suggested, _increment_last_digits(suggested), None
 
     else:
-        return filename_main, None
+        return filename_main, None, None
 
 
 def _sort_fuzzy_results(fuzzy_results_filtered):

--- a/plugins/module_utils/software_center/search.py
+++ b/plugins/module_utils/software_center/search.py
@@ -309,25 +309,24 @@ def _prepare_search_filename(filename):
         suggested = filename_parts[0]
         return suggested, _increment_last_digits(suggested)
 
-
     # Revision version will be kept to ensure correct component versions.
     # Example: IMDB_SERVER20_067_4-80002046.SAR returns IMDB_SERVER20_067 (Rev 67)
     # Example: IMDB_AFL20_077_0-80002045.SAR returns IMDB_AFL20_077 (Rev 77)
     # Example: IMDB_AFL100_102P_41-10012328.SAR returns MDB_AFL100_102 (Rev 102)
     # Example: IMDB_LCAPPS_122P_3300-20010426.SAR returns IMDB_LCAPPS_122 (Rev 122)
     # Example: IMDB_LCAPPS_2067P_400-80002183.SAR returns IMDB_LCAPPS_2067 (Rev 67)
-    elif filename_base.startswith(('IMDB_SERVER', 'IMDB_AFL', 'IMDB_LCAPPS_1', 'IMDB_LCAPPS_2')):       
+    elif filename_base.startswith(('IMDB_SERVER', 'IMDB_AFL', 'IMDB_LCAPPS_1', 'IMDB_LCAPPS_2')):
         # Remove P from the 3rd element (index 2) to improve fuzzy search.
         if len(filename_parts) > 2:
-            filename_parts[2] = filename_parts[2].rstrip('Pp') 
+            filename_parts[2] = filename_parts[2].rstrip('Pp')
         # Re-join the first three elements -> "IMDB_AFL100_102"
         suggested = "_".join(filename_parts[:3])
         return suggested, None
 
     # Example: IMDB_CLIENT20_021_31-80002082.SAR returns IMDB_CLIENT20_021
-    elif filename_base.startswith('IMDB_CLIENT'):       
+    elif filename_base.startswith('IMDB_CLIENT'):
         if len(filename_parts) > 2:
-            filename_parts[2] = filename_parts[2].rstrip('Pp') 
+            filename_parts[2] = filename_parts[2].rstrip('Pp')
         suggested = "_".join(filename_parts[:3])
         return suggested, _increment_last_digits(suggested)
 

--- a/plugins/module_utils/software_center/search.py
+++ b/plugins/module_utils/software_center/search.py
@@ -218,7 +218,7 @@ def _search_software_fuzzy(client, query):
 
     # Extract ID and prepare suggested filename prefix
     filename_id = filename_base.split('-')[-1]
-    suggested_filename, suggested_filename_next, _ = _prepare_search_filename(query)
+    suggested_filename, suggested_filename_next, suggested_filename_base = _prepare_search_filename(query)
     has_wildcard = '*' in query
 
     fuzzy_results = []

--- a/plugins/module_utils/software_center/search.py
+++ b/plugins/module_utils/software_center/search.py
@@ -61,14 +61,32 @@ def find_file(client, name, deduplicate, search_alternatives):
                 f'Wildcard search requires search_alternatives to be enabled.'
             )
 
-        # search_alternatives is enabled - validate format for fuzzy search.
-        if not (has_dash and has_extension):
-            raise FileNotFoundError(
-                f'File "{name}" is not available.\n'
-                f'Wildcard queries must follow specific format.\n'
-                f'Format: "PREFIX*-ID.EXT"\n'
-                f'Example: "SAPEXE_1*-80002630.SAR"'
-            )
+        # One wildcard was detected, validate wildcard position and format.
+        if wildcard_count > 0:
+            # We have to ensure that only correct pattern is accepted: PREFIX*-ID.EXT
+            # Having wildcard in other places would result in API timeouts
+            # or files for different components and platforms.
+            # [^-]+ = one or more non-dash characters
+            # \* = wildcard character
+            # - = single dash separator
+            # \d{8} = exactly 8 digits (SAP file IDs are always 8 digits)
+            # \. = dot character
+            # [a-zA-Z]+ = file extension (SAR, EXE, rpm, sar, etc.)
+            wildcard_pattern = r'^[^-]+\*-\d{8}\.[a-zA-Z]+$'
+            if not re.match(wildcard_pattern, name):
+                raise FileNotFoundError(
+                    f'File "{name}" is not available.\n'
+                    f'Wildcard queries must follow specific format.\n'
+                    f'Format: "PREFIX*-ID.EXT" where:\n'
+                    f' - PREFIX must have at least one character before wildcard\n'
+                    f' - Wildcard (*) must be in PREFIX position only\n'
+                    f' - Single dash (-) separates prefix and ID\n'
+                    f' - ID must be exactly 8 digits\n'
+                    f'Valid: "SAPEXE_1*-80002630.SAR"\n'
+                    f'Invalid: "*-80002630.SAR" (no prefix - too broad)\n'
+                    f'Invalid: "SAPEXE_1-*.SAR" (wildcard in ID position)\n'
+                    f'Invalid: "igsexe_*-7000.sar" (ID must be 8 digits, not 4)'
+                )
 
         try:
             software_fuzzy_found = _search_software_fuzzy(client, name)

--- a/plugins/modules/software_center_download.py
+++ b/plugins/modules/software_center_download.py
@@ -39,6 +39,10 @@ options:
   search_query:
     description:
       - Filename of the SAP software to download.
+      - Supports wildcard format for version matching with C(search_alternatives) enabled.
+      - "Wildcard format: C(PREFIX*-ID.EXT) where the asterisk replaces the version number."
+      - "Example: C(SWPM20SP2*-80003424.SAR) matches all versions like SWPM20SP23, SWPM20SP24, etc."
+      - Only one wildcard is allowed per query.
     required: false
     default: ''
     type: str
@@ -61,15 +65,20 @@ options:
     type: str
   deduplicate:
     description:
-      - "Specifies how to handle multiple search results for the same filename.
-      - Choices are `first` (oldest) or `last` (newest)."
+      - Specifies how to handle multiple search results when using wildcards.
+      - Only applies when C(search_alternatives) is enabled and multiple versions are found.
+      - "Choices: C(first) returns the oldest version, C(last) returns the newest version."
+      - If left empty and multiple results are found, an error with all available versions will be displayed.
     choices: [ 'first', 'last', '' ]
     required: false
     default: ''
     type: str
   search_alternatives:
     description:
-      - Enable search for alternative packages, when filename is not available.
+      - Enable search for alternative packages when the exact filename is not available.
+      - Required when using wildcard queries in C(search_query).
+      - Only works for files following the format C(PREFIX-ID.EXT) with a dash and extension.
+      - Special media files without this pattern (e.g., C(S4CORE107_INST_EXPORT_1.zip)) must use exact filenames.
     required: false
     default: false
     type: bool
@@ -94,28 +103,58 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Download using search query
+- name: Download using exact filename search
   community.sap_launchpad.software_center_download:
-    suser_id: 'SXXXXXXXX'
-    suser_password: 'password'
+    suser_id: "Enter SAP S-User ID"
+    suser_password: "Enter SAP S-User Password"
     search_query: 'SAPCAR_1324-80000936.EXE'
     dest: "/tmp/"
+
 - name: Download using direct link and filename
   community.sap_launchpad.software_center_download:
-    suser_id: 'SXXXXXXXX'
-    suser_password: 'password'
+    suser_id: "Enter SAP S-User ID"
+    suser_password: "Enter SAP S-User Password"
     download_link: 'https://softwaredownloads.sap.com/file/0010000000048502015'
     download_filename: 'IW_FNDGC100.SAR'
     dest: "/tmp/"
-- name: Download a file, searching for alternatives and validating checksum
+
+- name: Download latest version using wildcard search
   community.sap_launchpad.software_center_download:
-    suser_id: 'SXXXXXXXX'
-    suser_password: 'password'
+    suser_id: "Enter SAP S-User ID"
+    suser_password: "Enter SAP S-User Password"
+    search_query: 'SWPM20SP2*-80003424.SAR'
+    dest: "/sap_media"
+    search_alternatives: true
+    deduplicate: "last"
+
+- name: Download oldest version using wildcard search
+  community.sap_launchpad.software_center_download:
+    suser_id: "Enter SAP S-User ID"
+    suser_password: "Enter SAP S-User Password"
+    search_query: 'SAPHOSTAGENT*-80004822.SAR'
+    dest: "/sap_media"
+    search_alternatives: true
+    deduplicate: "first"
+
+- name: Download with checksum validation
+  community.sap_launchpad.software_center_download:
+    suser_id: "Enter SAP S-User ID"
+    suser_password: "Enter SAP S-User Password"
     search_query: 'IMDB_SERVER20_023_0-80002031.SAR'
     dest: "/sap_media"
     search_alternatives: true
     deduplicate: "last"
     validate_checksum: true
+
+- name: Dry run to check file availability without downloading
+  community.sap_launchpad.software_center_download:
+    suser_id: "Enter SAP S-User ID"
+    suser_password: "Enter SAP S-User Password"
+    search_query: 'SWPM20SP2*-80003424.SAR'
+    dest: "/sap_media"
+    search_alternatives: true
+    deduplicate: "last"
+    dry_run: true
 '''
 
 RETURN = r'''

--- a/plugins/modules/software_center_download.py
+++ b/plugins/modules/software_center_download.py
@@ -71,7 +71,7 @@ options:
       - If left empty and multiple results are found, an error with all available versions will be displayed.
     choices: [ 'first', 'last', '' ]
     required: false
-    default: ''
+    default: 'last'
     type: str
   search_alternatives:
     description:
@@ -198,7 +198,7 @@ def run_module():
         download_filename=dict(type='str', required=False, default=''),
         dest=dict(type='str', required=True),
         dry_run=dict(type='bool', required=False, default=False),
-        deduplicate=dict(type='str', required=False, default='', choices=['first', 'last', '']),
+        deduplicate=dict(type='str', required=False, default='last', choices=['first', 'last', '']),
         search_alternatives=dict(type='bool', required=False, default=False),
         validate_checksum=dict(type='bool', required=False, default=False)
     )

--- a/plugins/modules/software_center_download.py
+++ b/plugins/modules/software_center_download.py
@@ -65,7 +65,7 @@ options:
     type: str
   deduplicate:
     description:
-      - Specifies how to handle multiple search results when using wildcards.
+      - Specifies how to handle multiple search results.
       - Only applies when C(search_alternatives) is enabled and multiple versions are found.
       - "Choices: C(first) returns the oldest version, C(last) returns the newest version."
       - If left empty and multiple results are found, an error with all available versions will be displayed.

--- a/roles/sap_software_download/README.md
+++ b/roles/sap_software_download/README.md
@@ -323,11 +323,14 @@ If set to `false`, the role will execute dry run to validate S-User credentials.
 
 ### sap_software_download_deduplicate
 - _Type:_ `string`<br>
+- _Default:_ `last`<br>
 
 Specifies how to handle duplicate file results when using `sap_software_download_files`.<br>
 If multiple files with the same name are found, this setting determines which one to download.<br>
+
 - `first`: Download the first file found<br>
 - `last`: Download the last file found.<br>
+- `''`: No deduplication, will cause an error if multiple files with the same name are found.<br> 
 
 ### sap_software_download_validate_checksum
 - _Type:_ `bool`<br>

--- a/roles/sap_software_download/defaults/main.yml
+++ b/roles/sap_software_download/defaults/main.yml
@@ -85,9 +85,10 @@ sap_software_download_ignore_validate_credentials: false
 
 # Specifies how to handle duplicate file results when using `sap_software_download_files`.
 # If multiple files with the same name are found, this setting determines which one to download.
-#   `first`: Download the first file found.
-#   `last`: Download the last file found.
-# sap_software_download_deduplicate: first
+# - `first`: Download the first file found.
+# - `last`: Download the last file found.
+# - `''`: No deduplication, will cause an error if multiple files with the same name are found.
+sap_software_download_deduplicate: last
 
 # Enables checksum validation of existing files present in `sap_software_download_directory`.
 # This does not affect automatic checksum validation of downloaded files.

--- a/roles/sap_software_download/meta/argument_spec.yml
+++ b/roles/sap_software_download/meta/argument_spec.yml
@@ -157,8 +157,8 @@ argument_specs:
       sap_software_download_deduplicate:
         type: str
         required: false
-        default: "first"
-        choices: ["first", "last"]
+        default: "last"
+        choices: ["first", "last", ""]
         description:
           - Specifies how to handle duplicate file results when using `sap_software_download_files`.
           - If multiple files with the same name are found, this setting determines which one to download.

--- a/roles/sap_software_download/tasks/download_files.yml
+++ b/roles/sap_software_download/tasks/download_files.yml
@@ -8,7 +8,7 @@
     search_query: "{{ item }}"
     dest: "{{ sap_software_download_directory }}"
     search_alternatives: "{{ sap_software_download_find_alternatives | d(true) }}"
-    deduplicate: "{{ sap_software_download_deduplicate | d('') }}"
+    deduplicate: "{{ sap_software_download_deduplicate }}"
     validate_checksum: "{{ sap_software_download_validate_checksum | d(false) }}"
   # Loop condition acts as when conditional
   loop: "{{ sap_software_download_files if sap_software_download_use_venv | d(true) else [] }}"
@@ -31,7 +31,7 @@
     search_query: "{{ item }}"
     dest: "{{ sap_software_download_directory }}"
     search_alternatives: "{{ sap_software_download_find_alternatives | d(true) }}"
-    deduplicate: "{{ sap_software_download_deduplicate | d('') }}"
+    deduplicate: "{{ sap_software_download_deduplicate }}"
     validate_checksum: "{{ sap_software_download_validate_checksum | d(false) }}"
   # Loop condition acts as when conditional
   loop: "{{ sap_software_download_files if not sap_software_download_use_venv | d(true) else [] }}"
@@ -52,8 +52,16 @@
   ansible.builtin.fail:
     msg: |
       Download failed for following files: {{ __failed_items | map(attribute='item') | list | join(', ') }}
+
+      {% if not sap_software_download_find_alternatives | d(false) %}
       Either set `sap_software_download_find_alternatives` to `true` to search for alternative files
       or ignore this error with `sap_software_download_ignore_file_not_found` set to `true`.
+
+      {% endif %}
+      {% for failed_item in __failed_items %}
+      {{ failed_item.item }}: {{ failed_item.msg | d('') }}
+
+      {% endfor %}
   vars:
     __failed_items: "{{ __sap_software_download_files_results.results
       | selectattr('failed', 'defined') | selectattr('failed', 'true') }}"

--- a/roles/sap_software_download/tasks/pre_steps/01_include_variables.yml
+++ b/roles/sap_software_download/tasks/pre_steps/01_include_variables.yml
@@ -116,8 +116,10 @@
 - name: "Pre-Steps - Verify variable: sap_software_download_deduplicate"
   ansible.builtin.assert:
     that:
-      - sap_software_download_deduplicate in ['first', 'last']
+      - sap_software_download_deduplicate is defined
+      - sap_software_download_deduplicate is string
+      - sap_software_download_deduplicate in ['first', 'last', '']
     fail_msg: |
       Enter valid option for `sap_software_download_deduplicate` variable.
-      Options: first, last
-  when: sap_software_download_deduplicate is defined
+      Options: first, last or empty string ''.
+      NOTE: Empty string will cause an error if multiple files with the same name are found.

--- a/roles/sap_software_download/tasks/pre_steps/05_validate_relations.yml
+++ b/roles/sap_software_download/tasks/pre_steps/05_validate_relations.yml
@@ -12,7 +12,7 @@
         search_query: "{{ item }}"
         dest: "{{ sap_software_download_directory }}"
         search_alternatives: "{{ sap_software_download_find_alternatives | d(true) }}"
-        deduplicate: "{{ sap_software_download_deduplicate | d('') }}"
+        deduplicate: "{{ sap_software_download_deduplicate }}"
         dry_run: true
       # Loop condition acts as when conditional
       loop: "{{ sap_software_download_files if sap_software_download_use_venv | d(true) else [] }}"
@@ -37,7 +37,7 @@
         search_query: "{{ item }}"
         dest: "{{ sap_software_download_directory }}"
         search_alternatives: "{{ sap_software_download_find_alternatives | d(true) }}"
-        deduplicate: "{{ sap_software_download_deduplicate | d('') }}"
+        deduplicate: "{{ sap_software_download_deduplicate }}"
         dry_run: true
       # Loop condition acts as when conditional
       loop: "{{ sap_software_download_files if not sap_software_download_use_venv | d(true) else [] }}"


### PR DESCRIPTION
## Changes
This PR resolves issues reported in https://github.com/sap-linuxlab/community.sap_launchpad/issues/64, where deduplication was not providing correct results because sorting was incorrect. This sent me down a rabbit hole identifying additional issues in fuzzy search logic.

**New features:**
- Added conditional checks to fail fast with clear error messages for various invalid input combinations.
- New function to generate suggested filename + incremented (`+1`) filename for targeted searches that avoid API timeouts.
- Better error handling for SAP API 500 errors with actionable guidance (narrow search or retry later).

**Reworked:**
- Stricter wildcard handling:
  - Wildcards only allowed with format `PREFIX*-ID.EXT` (requires dash and extension).  
  - Always use comprehensive ID-based search to ensure all versions are found (fixes issue where `igsexe_*-70005417.sar` only found 1 of 7 available files).
- SAP HANA revision handling:
  - Prevent revision jumping for HANA files (IMDB_SERVER, IMDB_AFL, IMDB_LCAPPS) to avoid installation failures when SAP disables specific revision files.
- Removed redundant re-try of search for similar names, which was resolved by improving fuzzy search logic.
- Improved error messages: All error messages now include format examples and next steps.

**Fixes:**
- Fixed numerical sorting (was alphabetic) - now correctly orders versions (7 < 10 < 100 < 1500).
- Fixed zero-value handling in numeric sort check (`0` was treated as falsy).
- Fixed version increment boundary conditions (`99` → `None`, `9` → `None`).
- Fixed double wildcard crash (ValueError) - now shows clean error message.
- Added `SearchResultDescr` to pagination support.

### Search Logic Flow
The module now follows this search strategy:

**For exact filenames** (no wildcard):
1. Search by full filename from input parameter
2. If not found and `search_alternatives: true`:
   - Search by suggested name (e.g., `SWPM20SP23`), filter by File ID
   - If empty, search by incremented name (`SWPM20SP24`), filter by File ID
   - If still empty, fall back to comprehensive ID-based search. filter by suggested names
3. Filter results by extension, apply numerical sort and deduplicate logic

**For wildcard queries** (e.g., `SWPM20SP2*-80003424.SAR`):
1. Always use comprehensive ID-based search with pagination to ensure all matching versions are found
2. Filter results by suggested names
3. Filter results by extension, apply numerical sort and deduplicate logic

This ensures wildcards find all available versions while exact filename searches remain efficient.

## Tests
This PR was tested on SLES 16 using long list of combinations and it can be retested by using following snippets.
<details>
<summary>Click here to expand the code block for deduplication test example</summary>

```yaml
    - name: Testing deduplicate
      community.sap_launchpad.software_center_download:
        suser_id: "{{ sap_id_user }}"
        suser_password: "{{ sap_id_user_password }}"
        search_query: "SAPEXE_10*-80002630.SAR"
        dest: "/download"
        search_alternatives: true
        deduplicate: "{{ deduplicate_item }}"
        dry_run: true
      loop:
        - 'first'
        - 'last'
        - ''
      loop_control:
        loop_var: deduplicate_item
      register: download_task_deduplicate
      ignore_errors: true

    - name: Debug download_task_deduplicate
      ansible.builtin.debug:
        msg: |
          Deduplicate value: "{{ result_item.deduplicate_item }}"
          {{ result_item.msg }}
      loop: "{{ download_task_deduplicate.results }}"
      loop_control:
        loop_var: result_item
        label: "{{ result_item.deduplicate_item }}"

```
</details>
<details>
<summary>Click here to expand the code block for deduplication test example</summary>

```yaml
    - name: Testing fuzzy search with wildcards and alternatives
      community.sap_launchpad.software_center_download:
        suser_id: "{{ sap_id_user }}"
        suser_password: "{{ sap_id_user_password }}"
        search_query: "{{ scenario_item.name }}"
        dest: "/download"
        deduplicate: 'last'
        search_alternatives: "{{ scenario_item.alternatives }}"
        dry_run: true
      register: download_task_fuzzy_search
      loop:
        # File is available
        # Valid filename available to download
        - name: "SAPEXE_900-80002630.SAR"
          alternatives: false

        # Increment test to find alternative SP23
        - name: "SWPM20SP22_1-80003424.SAR"
          alternatives: true

        # Alternative SAP Software is available to download
        - name: "SAPEXE_90*-80002630.SAR"
          alternatives: true

        # File "SAPEXE" is not available.
        # Covers others like: KD75783.SAR, SWPM, S4CORE107_INST_EXPORT_1.zip
        - name: "SAPEXE"
          alternatives: false

        # To search for different versions, enable "search_alternatives" and use wildcard format.
        - name: "SAPEXE_TEST-80002630.SAR"
          alternatives: false

        # File "SAPEXE_TEST-80002630.SAR" is not available and no alternatives could be found.
        - name: "SAPEXE_TEST-80002630.SAR"
          alternatives: true

        # Only one wildcard (*) is allowed in the search query
        - name: "SAPEXE*_TEST*-80002630.SAR"
          alternatives: true

        # Wildcard search requires search_alternatives to be enabled.
        - name: "SAPEXE_TEST*80002630.SAR"
          alternatives: false

        # Wildcard queries must follow specific format.
        - name: "SAPEXE_TEST*80002630.SAR"
          alternatives: true

        # Wildcard queries must follow specific format.
        - name: "SAPEXE_TEST-80002630*SAR"
          alternatives: true

        # Wildcard queries must follow specific format.
        - name: "SAPEXE_TEST-*.SAR"
          alternatives: true

        # Increment test to find closest version to no version.
        - name: "igsexe_-70005417.sar"
          alternatives: true
      loop_control:
        loop_var: scenario_item
      ignore_errors: true

    - name: Debug download_task_fuzzy_search
      ansible.builtin.debug:
        msg: |
          Filename:             {{ result_item.scenario_item.name }}
          Search Alternatives:  {{ result_item.scenario_item.alternatives }}
          {{ result_item.msg }}
      loop: "{{ download_task_fuzzy_search.results }}"
      loop_control:
        loop_var: result_item
        label: "{{ result_item.scenario_item.name }}"

```
</details>

Example of test outcome showing various new messages and combinations:
```yaml
TASK [Debug download_task_fuzzy_search] ********************************************************************************************************************
 [started TASK: Debug download_task_fuzzy_search on ae1ascs]
ok: [localhost] => (item=SAPEXE_900-80002630.SAR) =>
    msg: |-
        Filename:             SAPEXE_900-80002630.SAR
        Search Alternatives:  False
        SAP Software is available to download: SAPEXE_900-80002630.SAR
ok: [localhost] => (item=SWPM20SP22_1-80003424.SAR) =>
    msg: |-
        Filename:             SWPM20SP22_1-80003424.SAR
        Search Alternatives:  True
        Alternative SAP Software is available to download: SWPM20SP23_4-80003424.SAR - original file SWPM20SP22_1-80003424.SAR is not available
ok: [localhost] => (item=SAPEXE_90*-80002630.SAR) =>
    msg: |-
        Filename:             SAPEXE_90*-80002630.SAR
        Search Alternatives:  True
        Alternative SAP Software is available to download: SAPEXE_900-80002630.SAR - original file SAPEXE_90*-80002630.SAR is not available
ok: [localhost] => (item=SAPEXE) =>
    msg: |-
        Filename:             SAPEXE
        Search Alternatives:  False
        File "SAPEXE" is not available.
ok: [localhost] => (item=SAPEXE_TEST-80002630.SAR) =>
    msg: |-
        Filename:             SAPEXE_TEST-80002630.SAR
        Search Alternatives:  False
        File "SAPEXE_TEST-80002630.SAR" is not available.
        To search for different versions, enable "search_alternatives" and use wildcard format.
        Format: "PREFIX*-ID.EXT"
        Example: "SAPEXE_1*-80002630.SAR"
ok: [localhost] => (item=SAPEXE_TEST-80002630.SAR) =>
    msg: |-
        Filename:             SAPEXE_TEST-80002630.SAR
        Search Alternatives:  True
        File "SAPEXE_TEST-80002630.SAR" is not available and no alternatives could be found.
ok: [localhost] => (item=SAPEXE*_TEST*-80002630.SAR) =>
    msg: |-
        Filename:             SAPEXE*_TEST*-80002630.SAR
        Search Alternatives:  True
        File "SAPEXE*_TEST*-80002630.SAR" is not available.
        Only one wildcard (*) is allowed in the search query.
ok: [localhost] => (item=SAPEXE_TEST*80002630.SAR) =>
    msg: |-
        Filename:             SAPEXE_TEST*80002630.SAR
        Search Alternatives:  False
        File "SAPEXE_TEST*80002630.SAR" is not available.
        Wildcard search requires search_alternatives to be enabled.
ok: [localhost] => (item=SAPEXE_TEST*80002630.SAR) =>
    msg: |-
        Filename:             SAPEXE_TEST*80002630.SAR
        Search Alternatives:  True
        File "SAPEXE_TEST*80002630.SAR" is not available.
        Wildcard queries must follow specific format.
        Format: "PREFIX*-ID.EXT" where:
         - PREFIX must have at least one character before wildcard
         - Wildcard (*) must be in PREFIX position only
         - Single dash (-) separates prefix and ID
         - ID must be exactly 8 digits
        Valid: "SAPEXE_1*-80002630.SAR"
        Invalid: "*-80002630.SAR" (no prefix - too broad)
        Invalid: "SAPEXE_1-*.SAR" (wildcard in ID position)
        Invalid: "igsexe_*-7000.sar" (ID must be 8 digits, not 4)
ok: [localhost] => (item=SAPEXE_TEST-80002630*SAR) =>
    msg: |-
        Filename:             SAPEXE_TEST-80002630*SAR
        Search Alternatives:  True
        File "SAPEXE_TEST-80002630*SAR" is not available.
        Wildcard queries must follow specific format.
        Format: "PREFIX*-ID.EXT" where:
         - PREFIX must have at least one character before wildcard
         - Wildcard (*) must be in PREFIX position only
         - Single dash (-) separates prefix and ID
         - ID must be exactly 8 digits
        Valid: "SAPEXE_1*-80002630.SAR"
        Invalid: "*-80002630.SAR" (no prefix - too broad)
        Invalid: "SAPEXE_1-*.SAR" (wildcard in ID position)
        Invalid: "igsexe_*-7000.sar" (ID must be 8 digits, not 4)
ok: [localhost] => (item=SAPEXE_TEST-*.SAR) =>
    msg: |-
        Filename:             SAPEXE_TEST-*.SAR
        Search Alternatives:  True
        File "SAPEXE_TEST-*.SAR" is not available.
        Wildcard queries must follow specific format.
        Format: "PREFIX*-ID.EXT" where:
         - PREFIX must have at least one character before wildcard
         - Wildcard (*) must be in PREFIX position only
         - Single dash (-) separates prefix and ID
         - ID must be exactly 8 digits
        Valid: "SAPEXE_1*-80002630.SAR"
        Invalid: "*-80002630.SAR" (no prefix - too broad)
        Invalid: "SAPEXE_1-*.SAR" (wildcard in ID position)
        Invalid: "igsexe_*-7000.sar" (ID must be 8 digits, not 4)
ok: [localhost] => (item=igsexe_-70005417.sar) =>
    msg: |-
        Filename:             igsexe_-70005417.sar
        Search Alternatives:  True
        Alternative SAP Software is available to download: igsexe_0-70005417.sar - original file igsexe_-70005417.sar is not available
```





