### PR TITLE
collection: Update workflow with max parallel limit to reduce API issues

### DIFF
--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -6,8 +6,8 @@ name: Ansible Test - Sanity
 
 on:
   schedule:
-    # This is 01:05 UTC, which is 3:05 AM in Prague/CEST
-    - cron: '5 3 * * 1'
+    # This is 02:37 UTC, which is 4:37 AM in Prague/CEST
+    - cron: '37 2 * * 1'
 
   pull_request:
     branches:
@@ -22,12 +22,19 @@ jobs:
     name: Sanity (Supported Ⓐ${{ matrix.ansible }})
     strategy:
       fail-fast: false  # Disabled so we can see all failed combinations.
+
+      # Serialization: Only allow 2 jobs to run simultaneously.
+      # This helps with throughput issues on GitHub Gateway servers.
+      max-parallel: 2
+
       # Define a build matrix to test compatibility across multiple Ansible versions.
       # Each version listed below will spawn a separate job that runs in parallel.
       matrix:
         ansible:
           - 'stable-2.18'  # Python 3.11 - 3.13
           - 'stable-2.19'  # Python 3.11 - 3.13
+          - 'stable-2.20'  # Python 3.12 - 3.14
+          - 'stable-2.21'  # Python 3.12 - 3.14
           - 'devel'  # Test against the upcoming development version.
 
     steps:
@@ -47,6 +54,11 @@ jobs:
     continue-on-error: true  # This entire job is allowed to fail
     strategy:
       fail-fast: false  # Disabled so we can see all failed combinations.
+
+      # Serialization: Only allow 2 jobs to run simultaneously.
+      # This helps with throughput issues on GitHub Gateway servers.
+      max-parallel: 2
+
       # Define a build matrix to test compatibility across multiple Ansible versions.
       # Each version listed below will spawn a separate job that runs in parallel.
       matrix:


### PR DESCRIPTION
## Changes
- Add `max-parallel: 2` to limit amount of parallel jobs that are reaching GitHub Gateway to reduce chance to get error.
```console
ERROR: HTTP error 504 while getting https://github.com/ansible/ansible/archive/stable-2.14.tar.gz

ERROR: Could not install requirement https://github.com/ansible/ansible/archive/stable-2.14.tar.gz because of HTTP error 504 Server Error: Gateway Time-out for url: https://github.com/ansible/ansible/archive/stable-2.14.tar.gz for URL https://github.com/ansible/ansible/archive/stable-2.14.tar.gz

Error: Process completed with exit code 1.
```

- Move scheduled time to uncommon minute to lower chance of clashing with other workflows. 